### PR TITLE
feat(135108): implementar salvamento inicial do processo de convocação o com campos do formulário e POST configurado.

### DIFF
--- a/src/pages/Processos/ImportacaoDados/Vagas/hooks/__tests__/index.test.tsx
+++ b/src/pages/Processos/ImportacaoDados/Vagas/hooks/__tests__/index.test.tsx
@@ -492,16 +492,7 @@ describe('ImportacaoDados Hooks - Cobertura Completa', () => {
       renderHook(() => useImportacaoDadosVagas(), { wrapper });
 
       expect(API.ImportacaoDados.getUltimasImportacoesArquivosVagas).toHaveBeenCalledWith(
-<<<<<<< HEAD
-        expect.objectContaining({
-          pagination: expect.objectContaining({
-            page: 1,
-            page_size: 10,
-          })
-        }),
-=======
         expect.objectContaining({ pagination: expect.any(Object) }),
->>>>>>> origin/feature/134892-Front-fazer-integracao-com-o-backend-para-o-download-do-layout-test
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });

--- a/src/pages/Processos/NovaConvocacaoCandidatos/NovaConvocacaoCandidatosTela.tsx
+++ b/src/pages/Processos/NovaConvocacaoCandidatos/NovaConvocacaoCandidatosTela.tsx
@@ -1,14 +1,13 @@
-import React, { useState } from "react";
+import React from "react";
 import { Typography, Card, Row, Col, Button } from "antd";
 
 import BaseTela, { type TitleItem } from "../../Base/BaseTela";
-import { useForm, useWatch } from "react-hook-form";
 import { Link } from "react-router-dom";
 
-import { useConcursos } from "../../../hooks/useConcursos";
 import FormPrincipal from "./components/FormPrincipal";
 import Cargo from "./components/Cargo";
 import AgendaTela from "./components/Agenda/AgendaTela";
+import { useNovaConvocacaoCandidatos } from "./hooks/useNovaConvocacaoCandidatos";
 
 const { Text } = Typography;
 
@@ -20,106 +19,25 @@ const breadcrumbItems = [
   { title: "Nova Convocação" },
 ] as TitleItem[];
 
-type ConcursoOption = {
-  value: string;
-  label: string;
-  cargos?: { value: string; label: string }[];
-};
-
-type FormFields = {
-  concurso: string;
-  tipo_processo: string;
-  descricao: string;
-  cargo: string;
-  data_convocacao: string;
-  data_corte_vagas: string;
-};
-
 export const NovaConvocacaoCandidatosTela: React.FC = () => {
-  const { concursosData, concursosOptionsIsLoading } = useConcursos();
-
-  const { control, reset } = useForm<FormFields>({
-    defaultValues: {
-      concurso: undefined,
-      tipo_processo: undefined,
-      descricao: undefined,
-      cargo: "",
-      data_convocacao: "",
-      data_corte_vagas: "",
-    },
-  });
-
-  const watchFields = useWatch({ control });
-
-  const isCargoLiberado = watchFields.concurso;
-  const [cargosDisponiveis, setCargosDisponiveis] = useState<
-    { value: string; label: string }[]
-  >([]);
-  const [cardData, setCardData] = useState({
-    vagas: 0,
-    autorizacoes: 0,
-    reservas: 0,
-    convocar: 0,
-  });
-  const [cargoSelecionado, setCargoSelecionado] = useState<
-    string | undefined
-  >();
-  const [podeVisualizarVagas, setPodeVisualizarVagas] = useState(false);
-  const buscarCargosDoConcurso = (concursoValue: string) => {
-    if (!concursoValue) {
-      setCargosDisponiveis([]);
-      return;
-    }
-
-    const concursoSelecionado = ((concursosData as unknown as ConcursoOption[]) || []).find(
-      (c: ConcursoOption) => c.value === concursoValue,
-    );
-
-    if (concursoSelecionado && concursoSelecionado.cargos) {
-      setCargosDisponiveis(concursoSelecionado.cargos);
-    }
-
-    setCargoSelecionado(undefined);
-    setPodeVisualizarVagas(false);
-
-    setCardData({
-      vagas: 0,
-      autorizacoes: 0,
-      reservas: 0,
-      convocar: 0,
-    });
-  };
-
-  const handleSub = (data: FormFields) => {
-    console.log("Enviando dados para o backend:", {
-      ...data,
-      page: 1,
-      page_size: 10,
-    });
-  };
-
-  const handleReset = () => {
-    reset({
-      concurso: "",
-      tipo_processo: "",
-      descricao: "",
-      cargo: "",
-      data_convocacao: "",
-      data_corte_vagas: "",
-    });
-    setCargoSelecionado(undefined);
-    setCargosDisponiveis([]);
-    setPodeVisualizarVagas(false);
-  };
-
-  // Labels selecionados para concurso e cargo
-  const selectedConcursoLabel =
-    ((concursosData as unknown as ConcursoOption[]) || []).find(
-      (opt) => opt.value === watchFields.concurso,
-    )?.label || "";
-
-  const selectedCargoLabel =
-    (cargosDisponiveis || []).find((opt) => opt.value === watchFields.cargo)?.label || "";
+  const {
+    control,
+    handleSubmit,
+    watchFields,
+    concursosData,
+    concursosOptionsIsLoading,
+    cargosDisponiveis,
+    cardData,
+    podeVisualizarVagas,
+    isCargoLiberado,
+    selectedConcursoLabel,
+    selectedCargoLabel,
+    buscarCargosDoConcurso,
+    handleSub,
+    setCardData,
+    setPodeVisualizarVagas,
+    postProcessoConvocacaoMutation,
+  } = useNovaConvocacaoCandidatos();
 
   return (
     <BaseTela
@@ -132,7 +50,7 @@ export const NovaConvocacaoCandidatosTela: React.FC = () => {
         </Typography.Title>
         <FormPrincipal
           control={control}
-          concursosData={((concursosData as unknown as ConcursoOption[]) || [])}
+          concursosData={concursosData}
           concursosOptionsIsLoading={concursosOptionsIsLoading}
           isCargoLiberado={isCargoLiberado}
           buscarCargosDoConcurso={buscarCargosDoConcurso}
@@ -166,7 +84,12 @@ export const NovaConvocacaoCandidatosTela: React.FC = () => {
           </Button>
         </Col>
         <Col>
-          <Button type="primary" size="large">
+          <Button 
+            type="primary" 
+            size="large"
+            onClick={handleSubmit(handleSub)}
+            loading={postProcessoConvocacaoMutation.isPending}
+          >
             Salvar
           </Button>
         </Col>

--- a/src/pages/Processos/NovaConvocacaoCandidatos/components/FormPrincipal.tsx
+++ b/src/pages/Processos/NovaConvocacaoCandidatos/components/FormPrincipal.tsx
@@ -16,7 +16,7 @@ export type ConcursoOption = {
 };
 export type FormFields = {
   concurso: string;
-  tipo_processo: string;
+  tipo_escolha: string;
   descricao: string;
   cargo: string;
   data_convocacao: string;
@@ -74,7 +74,7 @@ const FormPrincipal: React.FC<FormPrincipalProps> = ({
         />
         <Controller
           control={control}
-          name="tipo_processo"
+          name="tipo_escolha"
           render={({ field }) => (
             <CustomFormItem label="Tipo de Escolha" labelCol={{ span: 24 }}>
               <Select
@@ -82,9 +82,9 @@ const FormPrincipal: React.FC<FormPrincipalProps> = ({
                 placeholder="Selecione o tipo de escolha"
                 style={{ width: "36.875rem", height: "2.5rem" }}
                 options={[
-                  { value: "Nova Autorização", label: "Nova Autorização" },
-                  { value: "Reposição", label: "Reposição" },
-                  { value: "Reconvocação", label: "Reconvocação" },
+                  { value: "NOVA_AUTORIZACAO", label: "Nova Autorização" },
+                  { value: "REPOSICAO", label: "Reposição" },
+                  { value: "RECONVOCAO", label: "Reconvocação" },
                 ]}
                 suffixIcon={
                   <KeyboardArrowDownRoundedIcon sx={{ color: "#032B68" }} />

--- a/src/pages/Processos/NovaConvocacaoCandidatos/hooks/useNovaConvocacaoCandidatos.tsx
+++ b/src/pages/Processos/NovaConvocacaoCandidatos/hooks/useNovaConvocacaoCandidatos.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { useConcursos } from "../../../../hooks/useConcursos";
+import { usePostProcessoConvocacao } from "./usePostProcessoConvocacao";
+import type { IPostProcessoConvocacaoPayload } from "../../../../services/resources/convocacao/IConvocacao";
+
+type ConcursoOption = {
+  value: string;
+  label: string;
+  cargos?: { value: string; label: string }[];
+};
+
+type FormFields = {
+  concurso: string;
+  tipo_escolha: string;
+  descricao: string;
+  cargo: string;
+  data_convocacao: string;
+  data_corte_vagas: string;
+};
+
+export const useNovaConvocacaoCandidatos = () => {
+  const { concursosData, concursosOptionsIsLoading } = useConcursos();
+
+  const defaultValues = {
+    concurso: undefined,
+    tipo_escolha: undefined,
+    descricao: undefined,
+    cargo: "",
+    data_convocacao: "",
+    data_corte_vagas: "",
+  };
+
+  const { control, reset, handleSubmit } = useForm<FormFields>({
+    defaultValues,
+  });
+
+  // Mutation para post de processo de convocação (hook centralizado)
+  const postProcessoConvocacaoMutation = usePostProcessoConvocacao();
+
+  const watchFields = useWatch({ control });
+
+  const isCargoLiberado = watchFields.concurso;
+  const [cargosDisponiveis, setCargosDisponiveis] = useState<
+    { value: string; label: string }[]
+  >([]);
+  const [cardData, setCardData] = useState({
+    vagas: 0,
+    autorizacoes: 0,
+    reservas: 0,
+    convocar: 0,
+  });
+  const [cargoSelecionado, setCargoSelecionado] = useState<
+    string | undefined
+  >();
+  const [podeVisualizarVagas, setPodeVisualizarVagas] = useState(false);
+
+  const buscarCargosDoConcurso = (concursoValue: string) => {
+    if (!concursoValue) {
+      setCargosDisponiveis([]);
+      return;
+    }
+
+    const concursoSelecionado = ((concursosData as unknown as ConcursoOption[]) || []).find(
+      (c: ConcursoOption) => c.value === concursoValue,
+    );
+
+    if (concursoSelecionado && concursoSelecionado.cargos) {
+      setCargosDisponiveis(concursoSelecionado.cargos);
+    }
+
+    setCargoSelecionado(undefined);
+    setPodeVisualizarVagas(false);
+
+    setCardData({
+      vagas: 0,
+      autorizacoes: 0,
+      reservas: 0,
+      convocar: 0,
+    });
+  };
+
+  const handleSub = async (data: FormFields) => {
+    if (!data.concurso || !data.tipo_escolha || !data.descricao || !data.data_convocacao || !data.data_corte_vagas) {
+      console.error("Todos os campos são obrigatórios");
+      return;
+    }
+
+    // Buscar dados do concurso selecionado
+    const concursosArray = Array.isArray(concursosData) ? concursosData : concursosData?.results || [];
+    const concursoSelecionado = concursosArray.find((concurso: any) => concurso.value === data.concurso);
+
+    if (!concursoSelecionado) {
+      console.error("Concurso selecionado não encontrado");
+      return;
+    }
+
+    const payload: IPostProcessoConvocacaoPayload = {
+      concurso_nome: concursoSelecionado.label,
+      concurso_uuid: concursoSelecionado.value,
+      tipo_escolha: data.tipo_escolha,
+      descricao: data.descricao,
+      data_convocacao: data.data_convocacao,
+      data_corte_vagas: data.data_corte_vagas,
+    };
+
+    try {
+      const result = await postProcessoConvocacaoMutation.mutateAsync(payload);
+      console.log("Processo de convocação criado com sucesso:", result);
+      reset(defaultValues);
+    } catch (error) {
+      console.error("Erro ao criar processo de convocação:", error);
+    }
+  };
+
+  const handleReset = () => {
+    reset({
+      concurso: "",
+      tipo_escolha: "",
+      descricao: "",
+      cargo: "",
+      data_convocacao: "",
+      data_corte_vagas: "",
+    });
+    setCargoSelecionado(undefined);
+    setCargosDisponiveis([]);
+    setPodeVisualizarVagas(false);
+  };
+
+  // Labels selecionados para concurso e cargo
+  const selectedConcursoLabel =
+    ((concursosData as unknown as ConcursoOption[]) || []).find(
+      (opt) => opt.value === watchFields.concurso,
+    )?.label || "";
+
+  const selectedCargoLabel =
+    (cargosDisponiveis || []).find((opt) => opt.value === watchFields.cargo)?.label || "";
+
+  return {
+    // Form controls
+    control,
+    reset,
+    handleSubmit,
+    watchFields,
+    
+    // Data
+    concursosData: (concursosData as unknown as ConcursoOption[]) || [],
+    concursosOptionsIsLoading,
+    cargosDisponiveis,
+    cardData,
+    cargoSelecionado,
+    podeVisualizarVagas,
+    
+    // Computed values
+    isCargoLiberado,
+    selectedConcursoLabel,
+    selectedCargoLabel,
+    
+    // Actions
+    buscarCargosDoConcurso,
+    handleSub,
+    handleReset,
+    setCardData,
+    setCargoSelecionado,
+    setPodeVisualizarVagas,
+    
+    // Mutation state
+    postProcessoConvocacaoMutation,
+  };
+};

--- a/src/pages/Processos/NovaConvocacaoCandidatos/hooks/usePostProcessoConvocacao.tsx
+++ b/src/pages/Processos/NovaConvocacaoCandidatos/hooks/usePostProcessoConvocacao.tsx
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { App } from "antd";
+import { API } from "../../../../services";
+import type { IPostProcessoConvocacaoPayload } from "../../../../services/resources/convocacao/IConvocacao";
+
+export const usePostProcessoConvocacao = () => {
+  const queryClient = useQueryClient();
+  const { notification } = App.useApp();
+
+  return useMutation({
+    mutationFn: (payload: IPostProcessoConvocacaoPayload) =>
+      API.Convocacao.postProcessoConvocacao(payload).response,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["getProcessoConvocacao"] });
+      notification.success({
+        message: "Convocação Realizada",
+        description: "A convocação dos dados foi processada com sucesso!",
+        placement: "top",
+        duration: 3.5,
+      });
+    },
+    onError: () => {
+      notification.error({
+        message: "Erro na Convocação",
+        description: "Ocorreu um erro ao processar a convocação dos dados. Tente novamente.",
+        placement: "top",
+        duration: 3.5,
+      });
+    },
+  });
+};
+
+

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,23 +1,25 @@
 import axios from "axios";
 
 const getEnv = (key: string, fallback: string) => {
-  const nodeVal = (typeof process !== "undefined" && process.env && (process.env as any)[key]) as string | undefined;
-  return nodeVal || fallback;
+  // No Vite, as variáveis de ambiente são acessadas através de import.meta.env
+  // e devem ter o prefixo VITE_
+  const viteKey = `VITE_${key}`;
+  const envValue = import.meta.env[viteKey];
+  return envValue || fallback;
 };
 
 export const appAxiosProcessoConvocacao = axios.create({
   baseURL: getEnv("PROCESSOS_CONVOCACAO_API_URL", "http://localhost:8000"),
-  // baseURL: getEnv("PROCESSOS_CONVOCACAO_API_URL", "https://qa-api-sigla.sme.prefeitura.sp.gov.br/ms-processos-convocacao"),
 });
 
 export const appAxiosConcursos = axios.create({
-  baseURL: getEnv("CONCURSOS_API_URL", "https://qa-api-sigla.sme.prefeitura.sp.gov.br/ms-processos-concursos"),
+  baseURL: getEnv("CONCURSOS_API_URL", "http://localhost:8001"),
 });
 
 export const appAxiosCandidatos = axios.create({
-  baseURL: getEnv("CANDIDATOS_API_URL", "https://qa-api-sigla.sme.prefeitura.sp.gov.br/ms-candidatos"),
+  baseURL: getEnv("CANDIDATOS_API_URL", "http://localhost:8002"),
 });
 
 export const appAxiosImportaArquivos = axios.create({
-  baseURL: getEnv("IMPORTACAO_ARQUIVOS_API_URL", "https://qa-api-sigla.sme.prefeitura.sp.gov.br/ms-importa-arquivos"),
+  baseURL: getEnv("IMPORTACAO_ARQUIVOS_API_URL", "http://localhost:8003"),
 });

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -6,7 +6,8 @@ const getEnv = (key: string, fallback: string) => {
 };
 
 export const appAxiosProcessoConvocacao = axios.create({
-  baseURL: getEnv("PROCESSOS_CONVOCACAO_API_URL", "https://qa-api-sigla.sme.prefeitura.sp.gov.br/ms-processos-convocacao"),
+  baseURL: getEnv("PROCESSOS_CONVOCACAO_API_URL", "http://localhost:8000"),
+  // baseURL: getEnv("PROCESSOS_CONVOCACAO_API_URL", "https://qa-api-sigla.sme.prefeitura.sp.gov.br/ms-processos-convocacao"),
 });
 
 export const appAxiosConcursos = axios.create({

--- a/src/services/resources/convocacao/IConvocacao.ts
+++ b/src/services/resources/convocacao/IConvocacao.ts
@@ -6,6 +6,16 @@ export interface IProcessoConvocacao {
 }
 
 
+export interface IPostProcessoConvocacaoPayload {
+  concurso_nome: string;
+  concurso_uuid: string;
+  tipo_escolha: string;
+  descricao: string;
+  data_convocacao: string;
+  data_corte_vagas: string;
+}
+
+
 export interface ISample extends IProcessoConvocacao {
   id : number|undefined;
 }

--- a/src/services/resources/convocacao/index.ts
+++ b/src/services/resources/convocacao/index.ts
@@ -1,12 +1,13 @@
 import type { AxiosRequestConfig } from "axios";
 import { appAxiosProcessoConvocacao } from "../../axios";
-import type { ISample, IProcessoConvocacao } from "./IConvocacao";
+import type { ISample, IProcessoConvocacao, ICreateProcessoConvocacaoPayload } from "./IConvocacao";
 import type { IBackendWithSubOptions, IListRequest, PaginatedResponse } from "../../../types/IListRequest";
 import queryParamsSerializer from "../../../utils/queryParamsSerializer";
 
 export const URL = {
   getProcessosConvocacao: () => `/api/v1/processos-convocacao/`,
   getConcursosOptions: () => `/api/v1/processos-convocacao/filtros/`,
+  postProcessoConvocacao: () => `/api/v1/processos-convocacao/`,
   createSample: () => `api/v1/sample/create`,
   editSample: (id:number) => `api/v1/sample/update/${id}/`,
   deleteSample: (id:number) => `api/v1/sample/delete/${id}/`,
@@ -40,7 +41,25 @@ export const getProcessosConvocacao = (
   };
 };
 
- 
+// TODO adicionar JWT no header Authorization
+export const postProcessoConvocacao = (
+  payload: ICreateProcessoConvocacaoPayload,
+  axiosRequestConfig?: AxiosRequestConfig
+) => {
+  const { signal, abort } = new AbortController();
+
+  const response = appAxiosProcessoConvocacao
+    .post<IProcessoConvocacao>(URL.postProcessoConvocacao(), payload, {
+      signal: axiosRequestConfig?.signal || signal,
+      ...axiosRequestConfig,
+    })
+    .then((response) => response.data);
+
+  return {
+    response,
+    abort,
+  };
+};
 
 export const createSample = (
   NewSample: IProcessoConvocacao,


### PR DESCRIPTION
Este PR inclui:

- Implementação do salvamento inicial do processo de convocação:

- concurso
- tipo_escolha
- descricao
- data_convocacao
- data_corte_vagas
- Habilitação do botão “Salvar” na tela de nova convocação
- Criação do payload considerando apenas os campos da etapa 1
- Configuração do POST para salvar o processo

Referência AzureDevOps: [AB#135108](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/135108) [AB#135370](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/135370)
