### PR TITLE
feature(144459): Melhoria no modal de histórico do concursado

### DIFF
--- a/src/pages/Processos/PesquisarConcursados/components/HistoricoCandidatoModal.tsx
+++ b/src/pages/Processos/PesquisarConcursados/components/HistoricoCandidatoModal.tsx
@@ -83,7 +83,7 @@ function buildAlteracoesFromReclassificacao(
         key: r.uuid ?? `recl-${i}`,
         data: formatarDataISO(r.criado_em ?? undefined),
         statusAnterior: de || "—",
-        statusNovo,
+        statusNovo: r.nova_classificacao ?? "—",
         motivo: r.motivo ?? "—",
       },
     });
@@ -164,24 +164,19 @@ function buildHistoricoSituacoes(results: EscolhaListItem[]): HistoricoSituacaoI
 }
 
 const labelStyle: React.CSSProperties = {
-  fontFamily: "Open Sans",
-  fontWeight: 600,
+  fontWeight: 700,
   fontSize: 16,
-  color: "#515151",
 };
 
 const valueStyle: React.CSSProperties = {
-  fontFamily: "Open Sans",
-  fontWeight: 400,
+  fontWeight: 550,
   fontSize: 16,
-  color: "#8C8C8C",
 };
 
 const sectionTitleStyle: React.CSSProperties = {
   fontFamily: "Open Sans",
   fontWeight: 700,
   fontSize: 16,
-  color: "#515151",
   marginTop: 24,
   marginBottom: 12,
 };
@@ -277,15 +272,15 @@ const HistoricoCandidatoModal: React.FC<HistoricoCandidatoModalProps> = ({
     >
       <Row gutter={[32, 24]} style={{ marginTop: 8, marginBottom: 24 }}>
         <Col span={6}>
-          <div style={labelStyle}>Candidato</div>
+          <div style={labelStyle}>Candidato:</div>
           <div style={{ ...valueStyle, marginTop: 12 }}>{nomeCandidato || "—"}</div>
         </Col>
         <Col span={10}>
-          <div style={labelStyle}>Concurso</div>
+          <div style={labelStyle}>Concurso:</div>
           <div style={{ ...valueStyle, marginTop: 12 }}>{concurso || "—"}</div>
         </Col>
         <Col span={8}>
-          <div style={labelStyle}>Cargo</div>
+          <div style={labelStyle}>Cargo:</div>
           <div style={{ ...valueStyle, marginTop: 12 }}>{cargo || "—"}</div>
         </Col>
       </Row>

--- a/src/services/resources/escolhas/index.ts
+++ b/src/services/resources/escolhas/index.ts
@@ -219,6 +219,7 @@ export type IBuscarCandidatosParams = {
 export type ReclassificacaoItem = {
   uuid?: string;
   desclassificado_de?: string;
+  nova_classificacao?: string;
   processo_uuid?: string | null;
   motivo?: string;
   executado_por?: string;


### PR DESCRIPTION
PR com ajuste no modal de histórico de concursado pra exibir novo campo do backend no status anterior da reclassficação

[AB#144459](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/144459)