### PR TITLE
feat(145422): Refatoração na forma de exibir a modalidade na tela de resumo da convocação

### DIFF
--- a/src/components/EstilosCompartilhados.ts
+++ b/src/components/EstilosCompartilhados.ts
@@ -341,16 +341,28 @@ font-size: 18px;
 font-weight: 600;
 `;
 
+export const TextSubHeadingPreto = styled(Text)`
+color:rgb(19, 19, 19);
+font-size: 18px;
+font-weight: 600;
+`;
 
 export const TextTituloCinza = styled(Text)`
 color: rgba(81, 81, 81, 0.80);
 font-size: 14px;
 font-weight: 600;
 line-height: 22px; 
-
 `;
+
+export const TextTitulo = styled(Text)`
+color: rgba(19, 19, 19, 0.8);
+font-size: 14px;
+font-weight: 600;
+line-height: 22px;
+`;
+
 export const TextSubTituloCinza = styled(Paragraph)`
-color: #838383;
+color:rgb(70, 70, 70);
 font-size: 14px;
 font-style: normal;
 font-weight: 400;

--- a/src/pages/CriarEditarConvocacao/Resumo.tsx
+++ b/src/pages/CriarEditarConvocacao/Resumo.tsx
@@ -17,6 +17,27 @@ import { resumoStyles } from "./Resumo/styles";
 
 const { Text } = Typography;
 
+function normalizeModalidade(value: any): string | undefined {
+  const s = String(value || "").toLowerCase();
+  if (!s) return undefined;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatResumoModalidadeFromResults(results?: any[]): string | undefined {
+  const list = Array.isArray(results) ? results : [];
+  if (list.length === 0) return undefined;
+  if (list.length === 1) {
+    return normalizeModalidade(list[0]?.modalidade);
+  }
+  const first = list[0];
+  const second = list[1];
+  const firstMod = String(first?.modalidade || "").toUpperCase();
+  if (firstMod === "ONLINE") {
+    return `${normalizeModalidade(first?.modalidade)} / ${normalizeModalidade(second?.modalidade)}`;
+  }
+  return normalizeModalidade(first?.modalidade);
+}
+
 const Resumo: React.FC = () => {
   const { can } = useGetPermissions();
   const canChangeProcessoConvocacao = can("change_processoconvocacao");
@@ -53,7 +74,6 @@ const Resumo: React.FC = () => {
       }
       agrupadas[cargoKey].push(agenda);
     });
-
     // Ordenar agendas dentro de cada cargo por data e horário
     Object.keys(agrupadas).forEach((cargoKey) => {
       agrupadas[cargoKey].sort((a, b) => {
@@ -79,14 +99,23 @@ const Resumo: React.FC = () => {
       cargoKey,
       cargoNome: agendas[0]?.cargo_nome || "Cargo desconhecido",
       agendas,
-      totalCandidatos: agendas.reduce((sum, agenda) => {
-        if (agenda?.retardatario) {
-          return sum;
+      totalCandidatos: (() => {
+        const first = agendas[0];
+        const modalidadeFirst = String(first?.modalidade || "").toUpperCase();
+        // Se a primeira agenda for ONLINE, usa a própria classificação da primeira agenda
+        if (modalidadeFirst === "ONLINE") {
+          return typeof first?.classificacao === "number" ? first.classificacao : 0;
         }
-        const valor =
-          typeof agenda?.classificacao === "number" ? agenda.classificacao : 0;
-        return sum + valor;
-      }, 0),
+        // Caso contrário, soma (ignorando retardatário)
+        return agendas.reduce((sum, agenda) => {
+          if (agenda?.retardatario) {
+            return sum;
+          }
+          const valor =
+            typeof agenda?.classificacao === "number" ? agenda.classificacao : 0;
+          return sum + valor;
+        }, 0);
+      })(),
     }));
   }, [agendasData]);
 
@@ -151,7 +180,7 @@ const Resumo: React.FC = () => {
   const prev = () => {
     navigate(`/processos/convocacao/editar/${uuid}/agenda`);
   };
-
+  console.log('agendasPorCargo', agendasPorCargo)
   return (
     <>
       <BaseTela
@@ -194,9 +223,7 @@ const Resumo: React.FC = () => {
               data={processoConvocacaoData}
               isLoading={processoConvocacaoIsLoading}
               useBlackText={isViewOnlyResumo}
-              modalidade={
-                agendasData?.results?.[0]?.modalidade ?? undefined
-              }
+              modalidade={formatResumoModalidadeFromResults((agendasData as any)?.results)}
             />
           )}
         </StyledCardWithoutBorder>

--- a/src/pages/CriarEditarConvocacao/Resumo/ResumoDoProcesso.tsx
+++ b/src/pages/CriarEditarConvocacao/Resumo/ResumoDoProcesso.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Row, Col, Spin } from "antd";
 import dayjs from "dayjs";
 
-import { TextSubHeading, TextSubTituloCinza, TextTituloCinza } from "../../../components/EstilosCompartilhados";
+import { TextSubHeadingPreto, TextSubTituloCinza, TextTitulo } from "../../../components/EstilosCompartilhados";
 import { resumoDoProcessoStyles } from "./styles";
 
 import type { IProcessoConvocacaoResumo } from "../../../services/resources/convocacao/IConvocacao";
@@ -39,33 +39,33 @@ const ResumoDoProcesso: React.FC<ResumoDoProcessoProps> = ({
     <Spin spinning={isLoading} tip="Carregando dados do processo..." size="large">
       <Row gutter={30}>
         <Col xs={24} md={24} style={resumoDoProcessoStyles.colWithMargin}>
-          <TextSubHeading style={blackStyle}>
+          <TextSubHeadingPreto style={blackStyle}>
             Dados do processo
-          </TextSubHeading>
+          </TextSubHeadingPreto>
         </Col>
 
         <Col xs={24} md={8}>
-          <TextTituloCinza style={blackStyle}>Concurso</TextTituloCinza>
+          <TextTitulo style={blackStyle}>Concurso</TextTitulo>
           <TextSubTituloCinza style={blackStyle}>{data.concurso_nome}</TextSubTituloCinza>
-          <TextTituloCinza style={blackStyle}>Data da convocação</TextTituloCinza>
+          <TextTitulo style={blackStyle}>Data da convocação</TextTitulo>
           <TextSubTituloCinza style={blackStyle}>
             {data.data_convocacao ? dayjs(data.data_convocacao).format("DD/MM/YYYY") : ""}
           </TextSubTituloCinza>
         </Col>
 
         <Col xs={24} md={8}>
-          <TextTituloCinza style={blackStyle}>Tipo de processo</TextTituloCinza>
+          <TextTitulo style={blackStyle}>Tipo de processo</TextTitulo>
           <TextSubTituloCinza style={blackStyle}>{getTipoEscolhaLabel(data.tipo_escolha)}</TextSubTituloCinza>
-          <TextTituloCinza style={blackStyle}>Data da publicação</TextTituloCinza>
+          <TextTitulo style={blackStyle}>Data da publicação</TextTitulo>
           <TextSubTituloCinza style={blackStyle}>
             {data.data_corte_vagas ? dayjs(data.data_corte_vagas).format("DD/MM/YYYY") : ""}
           </TextSubTituloCinza>
         </Col>
 
         <Col xs={24} md={8}>
-          <TextTituloCinza style={blackStyle}>Título</TextTituloCinza>
+          <TextTitulo style={blackStyle}>Título</TextTitulo>
           <TextSubTituloCinza style={blackStyle}>{data.descricao}</TextSubTituloCinza>
-          <TextTituloCinza style={blackStyle}>Modalidade</TextTituloCinza>
+          <TextTitulo style={blackStyle}>Modalidade</TextTitulo>
           <TextSubTituloCinza style={blackStyle}>
             {modalidade ?? "—"}
           </TextSubTituloCinza>


### PR DESCRIPTION
PR com refatoração na forma de exibir o valor da modalidade na tela de Resumo da convocação no caso de ter 1 agenda online, 1 ou mais presencial ou as 2 e também com algumas melhorias de css.

[AB#145422](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/145422) [AB#145409](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/145409)
