### PR TITLE
feat(146275): Candidatos retardatários agora podem fazer escolha após uma não escolha

### DIFF
--- a/src/pages/EscolhaCandidatos/components/EscolhaCandidatosModal.tsx
+++ b/src/pages/EscolhaCandidatos/components/EscolhaCandidatosModal.tsx
@@ -113,7 +113,6 @@ const EscolhaCandidatosModal: React.FC<EscolhaCandidatosModalProps> = ({
 
     const situacaoFromContext = context?.situacaoCodigo;
     const tipoVagaFromContext = context?.tipoVagaCodigo;
-
     return {
       situacao:
         situacaoFromContext && situacaoFromContext !== "pendente"
@@ -175,11 +174,18 @@ const EscolhaCandidatosModal: React.FC<EscolhaCandidatosModalProps> = ({
     shouldFetchVagas
   );
 
-  // Verifica se o modal está em modo somente leitura (candidato já tem escolha feita)
+  // Verifica se o modal está em modo somente leitura
+  // Regras:
+  // 1) Se for "não-escolha" em agenda de retardatários -> editável (false)
+  // 2) Se a situação do candidato for "pendente" -> somente leitura (true)
+  // 3) Demais casos -> editável (false)
   const isReadOnly = useMemo(() => {
-    return context?.situacaoCodigo !== "pendente";
-  }, [context?.situacaoCodigo]);
-
+    const agendaEhRetardatario = selectedAgendaData?.retardatario === true;
+    const isNaoEscolha = modalSituacao === "nao-escolha";
+    if (isNaoEscolha && agendaEhRetardatario) return false;
+    if (context?.situacaoCodigo === "pendente") return true;
+    return false; 
+  }, [context?.situacaoCodigo, selectedAgendaData?.retardatario, modalSituacao]);
   const vagasElegiveisPorTipo = useMemo(() => {
     if (!vagasData?.vagas || !Array.isArray(vagasData.vagas)) {
       return [];
@@ -514,9 +520,12 @@ const EscolhaCandidatosModal: React.FC<EscolhaCandidatosModalProps> = ({
           (uuid) => uuid !== candidatoUuid
         );
 
-        await API.Agenda.patchAgenda(agendaAtual.uuid, {
-          candidatos_uuids: candidatosAtualizados,
-        }).response;
+        // Só remove da agenda de retardatários quando a situação NÃO for "não-escolha"
+        if (modalSituacao !== "nao-escolha") {
+          await API.Agenda.patchAgenda(agendaAtual.uuid, {
+            candidatos_uuids: candidatosAtualizados,
+          }).response;
+        }
       } else {
         // Caso 2: Escolha feita em agenda normal
         // Encontrar e atualizar a agenda de retardatários
@@ -529,10 +538,11 @@ const EscolhaCandidatosModal: React.FC<EscolhaCandidatosModalProps> = ({
           const candidatosAtualizados = (agendaRetardatarios.candidatos_uuids || []).filter(
             (uuid) => uuid !== candidatoUuid
           );
-
-          await API.Agenda.patchAgenda(agendaRetardatarios.uuid, {
-            candidatos_uuids: candidatosAtualizados,
-          }).response;
+          if (modalSituacao !== "nao-escolha") {
+            await API.Agenda.patchAgenda(agendaRetardatarios.uuid, {
+              candidatos_uuids: candidatosAtualizados,
+            }).response;
+          }
         }
       }
 
@@ -548,7 +558,7 @@ const EscolhaCandidatosModal: React.FC<EscolhaCandidatosModalProps> = ({
       // Não mostrar erro ao usuário aqui, pois a escolha já foi salva
       // Apenas logar o erro
     }
-  }, [queryClient]);
+  }, [queryClient, modalSituacao]);
 
   const handleSalvarEscolha = useCallback(async () => {
     if (!context?.candidatoUuid) {


### PR DESCRIPTION
PR  com ajuste no fluxo de retardatários. Candidatos com uma não-escolha agora podem fazer escolha na agenda de retardatário.

AB#146725 [AB#145011](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/145011)