### PR TITLE
chore(146980): isolar preview HTML com ShadowContent na tela de Relatórios

### DIFF
--- a/src/pages/Relatorios/RelatoriosTela.tsx
+++ b/src/pages/Relatorios/RelatoriosTela.tsx
@@ -10,6 +10,7 @@ import AtaEscolhaCargoModal from "./components/AtaEscolhaCargoModal";
 import { usePostRelatorio } from "./hooks/usePostRelatorio";
 import { FilterSelect, FilterLabel } from "../EscolhaCandidatos/styles";
 import PersonalizacaoModal from "./components/PersonalizacaoModal";
+import ShadowContent from "./components/ShadowContent";
 import type { RelatorioLinha } from "../../services/resources/relatorios/IRelatorios";
 
 type RelatorioTipo = "EM_ANDAMENTO" | "FINALIZADO";
@@ -468,9 +469,9 @@ const RelatoriosTela: React.FC = () => {
             style={{ width: "100%", height: "80vh", border: 0 }}
           />
         ) : previewHtml ? (
-          <div
-            style={{ width: "100%", height: "80vh", overflow: "auto", padding: 0 }}
-            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          <ShadowContent
+            html={previewHtml}
+            style={{ width: "100%", height: "80vh", overflow: "auto", display: "block" }}
           />
         ) : (
           <pre style={{ margin: 0, padding: 16, whiteSpace: "pre-wrap" }}>

--- a/src/pages/Relatorios/components/ShadowContent.tsx
+++ b/src/pages/Relatorios/components/ShadowContent.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+interface ShadowContentProps {
+  html: string;
+  style?: React.CSSProperties;
+}
+
+const ShadowContent: React.FC<ShadowContentProps> = ({ html, style }) => {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    let shadow = host.shadowRoot;
+    if (!shadow) {
+      shadow = host.attachShadow({ mode: "open" });
+    }
+    shadow.innerHTML = html;
+  }, [html]);
+
+  return <div ref={hostRef} style={style} />;
+};
+
+export default ShadowContent;


### PR DESCRIPTION
Contexto
A pré-visualização de relatórios em HTML estava sujeita a interferência de estilos globais da aplicação, causando inconsistências visuais. 

Relatório com erro:

1. Súmula de Escolhas
2. Súmula de Reconvocados
3. Súmula de Não Escolha
4. Listagem de Escolhas por DREs
5. Resultado de Escolha de Vagas

O que foi feito:
- Criado/introduzido `ShadowContent` para renderizar HTML dentro de Shadow DOM.
- Ajustada a tela de Relatórios para usar `ShadowContent` no fluxo de preview HTML.

Motivo:
Garantir isolamento de estilos no preview HTML e maior fidelidade visual ao conteúdo retornado pelo MS-relatorio.

Impacto esperado:
- Menos quebra de layout no modal de visualização.
- Relatórios HTML com aparência mais consistente entre ambientes.