### PR TITLE
feat(147086)  ajusta paginação da listagem de habilitados

### DIFF
--- a/src/pages/ImportacaoDados/Habilitados/HistoricoHabilitadosTela.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/HistoricoHabilitadosTela.tsx
@@ -34,12 +34,14 @@ const HistoricoHabilitadosTela: React.FC = () => {
   const {
     importacoesArquivos,
     importacoesArquivosIsLoading,
-    listRequest,
-    onAntTableChange,
   } = useImportacaoDados();
 
   const [isErrosModalOpen, setIsErrosModalOpen] = useState(false);
   const [selectedRecord, setSelectedRecord] = useState<any | null>(null);
+  const [tablePagination, setTablePagination] = useState({
+    current: 1,
+    pageSize: 10,
+  });
 
   const { handleDownload, isDownloading } = useGetDownloadError(TipoImportacao.HABILITADOS);
 
@@ -125,7 +127,7 @@ const HistoricoHabilitadosTela: React.FC = () => {
               </CustomTitle>
               <StyledTable<any>
                 columns={columns}
-                dataSource={importacoesArquivos?.results || []}
+                dataSource={importacoesArquivos || []}
                 rowKey="id"
                 bordered
                 rowClassName={(_: any, index: number) =>
@@ -134,18 +136,23 @@ const HistoricoHabilitadosTela: React.FC = () => {
                 className="historico-table"
                 loading={importacoesArquivosIsLoading}
                 pagination={{
-                  current: listRequest.pagination.page,
-                  pageSize: 10,
-                  defaultPageSize: 10,
+                  current: tablePagination.current,
+                  pageSize: tablePagination.pageSize,
+                  showSizeChanger: true,
+                  onChange: (page: number, pageSize: number) => {
+                    setTablePagination({ current: page, pageSize });
+                  },
+                  onShowSizeChange: (_: number, pageSize: number) => {
+                    setTablePagination({ current: 1, pageSize });
+                  },
                   position: ["bottomLeft"],
-                  total: importacoesArquivos?.count,
+                  total: importacoesArquivos?.length || 0,
                   showTotal: (total: number, range: [number, number]) => (
                     <span style={{ marginLeft: 16 }}>
                       {`Mostrando ${range?.[0] ?? 0}-${range?.[1] ?? 0} de ${total ?? 0} registro(s)`}
                     </span>
                   ),
                 }}
-                onChange={onAntTableChange}
               />
             </Col>
           </Row>

--- a/src/pages/ImportacaoDados/Habilitados/hooks/useImportacoesArquivosHabilitados.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/hooks/useImportacoesArquivosHabilitados.tsx
@@ -5,10 +5,9 @@ import type { IListRequest } from "../../../../types/IListRequest";
 const useImportacoesArquivosHabilitados = (listRequest: IListRequest) => {
   // Query para buscar importações com parâmetros
   const { data: importacoesArquivos, isLoading: importacoesArquivosIsLoading } = useQuery({
-    queryKey: ["getImportacaoArquivosHabilitados", listRequest],
+    queryKey: ["getImportacaoArquivosHabilitados"],
     queryFn: ({ signal }) =>
-      API.ImportacaoDados.getImportacaoArquivosHabilitados(
-         listRequest,
+      API.ImportacaoDados.getImportacaoArquivosHabilitados(         
          { signal }
       ).response,
     staleTime: 1000 * 60 * 5,

--- a/src/pages/ImportacaoDados/Habilitados/hooks/usePostImportacaoArquivosHabilitados.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/hooks/usePostImportacaoArquivosHabilitados.tsx
@@ -11,7 +11,6 @@ export const usePostImportacaoArquivosHabilitados = () => {
     mutationFn: (payload: IImportacaoHabilitadosPayload) =>
       API.ImportacaoDados.postImportacaoArquivosHabilitados(payload).response,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["getImportacaoArquivosHabilitados"] });
       notification.success({
         message: "Importação Realizada",
         description: "A importação dos dados foi processada com sucesso!",
@@ -26,6 +25,9 @@ export const usePostImportacaoArquivosHabilitados = () => {
         placement: "top",
         duration: 3.5,
       });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["getImportacaoArquivosHabilitados"] });
     },
   });
 };

--- a/src/pages/Processos/ImportacaoDados/Habilitados/hooks/usePostImportacaoArquivosHabilitados.tsx
+++ b/src/pages/Processos/ImportacaoDados/Habilitados/hooks/usePostImportacaoArquivosHabilitados.tsx
@@ -11,7 +11,6 @@ export const usePostImportacaoArquivosHabilitados = () => {
     mutationFn: (payload: IImportacaoHabilitadosPayload) =>
       API.ImportacaoDados.postImportacaoArquivosHabilitados(payload).response,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["getImportacaoArquivosHabilitados"] });
       notification.success({
         message: "Importação Realizada",
         description: "A importação dos dados foi processada com sucesso!",
@@ -26,6 +25,9 @@ export const usePostImportacaoArquivosHabilitados = () => {
         placement: "top",
         duration: 3.5,
       });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["getImportacaoArquivosHabilitados"] });
     },
   });
 };

--- a/src/services/resources/importacaoDados/index.ts
+++ b/src/services/resources/importacaoDados/index.ts
@@ -88,14 +88,12 @@ export const postImportacaoArquivosHabilitados = (
 };
 
 // // TODO adicionar JWT no header Authorization
-export const getImportacaoArquivosHabilitados = (
-  params?: Record<string, any>,
+export const getImportacaoArquivosHabilitados = ( 
   axiosRequestConfig?: AxiosRequestConfig
 ) => {
   const { signal, abort } = new AbortController();
   const response = appAxiosImportaArquivos
-    .get<PaginatedResponse<IImportacaoFundacao>>(URL.getImportacaoArquivosHabilitados(), {
-      params,
+    .get<PaginatedResponse<IImportacaoFundacao>>(URL.getImportacaoArquivosHabilitados(), {      
       paramsSerializer: queryParamsSerializer,
       signal,
       ...axiosRequestConfig,


### PR DESCRIPTION
Este PR ajusta a paginação da tela de histórico de importação de habilitados.

**O que foi feito:**
1. ativa corretamente a troca de quantidade de itens por página
2. atualiza a página atual quando o usuário muda a paginação
3. mantém a exibição do total de registros de forma clara

**Resultado:**
1. o controle de tamanho da página passa a funcionar como esperado
2. a navegação da tabela fica mais previsível para o usuário

[AB#147001](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147001)