### PR TITLE
feat(148083)-tela adicionar usuario

### DIFF
--- a/src/components/FormStyle.ts
+++ b/src/components/FormStyle.ts
@@ -27,7 +27,7 @@ export const CustomFormItem = styled(FormItem)`
   .ant-input-number,
   .MuiInputBase-root {
     width: 100%;
-    height: 45px;
+    height: 2.5rem;
   }
     
   .ant-form-item-label {

--- a/src/pages/Gerenciar/AdicionarUsuario/AdicionarUsuarioTela.tsx
+++ b/src/pages/Gerenciar/AdicionarUsuario/AdicionarUsuarioTela.tsx
@@ -1,0 +1,217 @@
+import React from "react";
+import { Alert, Button, Col, Input, Row, Typography } from "antd";
+import { useNavigate } from "react-router-dom";
+
+import BaseTela, { type TitleItem } from "../../Base/BaseTela";
+import { CustomFormItem } from "../../../components/FormStyle";
+import { postBuscarUsuarioEol } from "../../../services/resources/usuarios";
+import type { IBuscarUsuarioEolResponse } from "../../../services/resources/usuarios";
+import { usePostCriarUsuario } from "./hooks/usePostCriarUsuario";
+
+import {
+  PageContainer,
+  ConteudoPagina,
+  FieldLabel,
+  SearchButton,
+} from "./styles";
+
+const { Text } = Typography;
+
+const AdicionarUsuarioTela: React.FC = () => {
+  const navigate = useNavigate();
+
+  const [rf, setRf] = React.useState("");
+  const [buscando, setBuscando] = React.useState(false);
+  const [dadosUsuario, setDadosUsuario] = React.useState<IBuscarUsuarioEolResponse | null>(null);
+  const [erro, setErro] = React.useState<string | null>(null);
+  const [erroAdicao, setErroAdicao] = React.useState<string | null>(null);
+
+  const criarUsuarioMutation = usePostCriarUsuario({
+    onSuccess: () => navigate("/gerenciar/gerenciamento-usuarios"),
+  });
+
+  const breadcrumbItems = [
+    {
+      title: (
+        <Text strong style={{ cursor: "pointer" }} onClick={() => navigate("/")}>
+          Home
+        </Text>
+      ),
+    },
+    {
+      title: (
+        <Text strong style={{ cursor: "pointer" }} onClick={() => navigate("/gerenciar")}>
+          Gerenciar
+        </Text>
+      ),
+    },
+    {
+      title: (
+        <Text
+          strong
+          style={{ cursor: "pointer" }}
+          onClick={() => navigate("/gerenciar/gerenciamento-usuarios")}
+        >
+          Gerenciamento de usuários
+        </Text>
+      ),
+    },
+    { title: "Adicionar usuário" },
+  ] as TitleItem[];
+
+  const handleBuscar = async () => {
+    const rfTrimmed = rf.trim();
+    if (!rfTrimmed) return;
+
+    setDadosUsuario(null);
+    setErro(null);
+    setErroAdicao(null);
+    setBuscando(true);
+
+    try {
+      const { response } = postBuscarUsuarioEol({ rf: rfTrimmed });
+      const data = await response;
+      setDadosUsuario(data);
+    } catch (e: any) {
+      const statusCode = e?.response?.status;
+      const detail = e?.response?.data?.detail;
+
+      if (statusCode === 400) {
+        setErro(detail || "Usuário já cadastrado no Sigla.");
+      } else if (statusCode === 404) {
+        setErro("Usuário não encontrado no EOL.");
+      } else {
+        setErro("Falha ao consultar o EOL. Tente novamente.");
+      }
+    } finally {
+      setBuscando(false);
+    }
+  };
+
+  const handleAdicionar = () => {
+    if (!dadosUsuario) return;
+
+    setErroAdicao(null);
+
+    criarUsuarioMutation.mutate(
+      {
+        username: dadosUsuario.username,
+        nome: dadosUsuario.nome,
+        email: dadosUsuario.email,
+      },
+      {
+        onError: (e: any) => {
+          const detail = e?.response?.data?.detail;
+          setErroAdicao(detail || "Falha ao criar o usuário. Tente novamente.");
+        },
+      }
+    );
+  };
+
+  return (
+    <PageContainer>
+      <BaseTela breadcrumbItems={breadcrumbItems} title="Adicionar usuário">
+        <ConteudoPagina>
+          <Text style={{ display: "block", marginBottom: 16 }}>
+            Preencha os campos para adicionar um novo usuário
+          </Text>
+          <Row gutter={[16, 0]} style={{ alignItems: "flex-end" }}>
+            <Col xs={24} md={20}>
+              <CustomFormItem
+                label={<FieldLabel>Registro funcional (RF)</FieldLabel>}
+                labelCol={{ span: 24 }}
+              >
+                <Input
+                  allowClear
+                  value={rf}
+                  onChange={(e) => {
+                    const onlyNumbers = e.target.value.replace(/\D/g, "");
+                    setRf(onlyNumbers);
+                    setDadosUsuario(null);
+                    setErro(null);
+                    setErroAdicao(null);
+                  }}
+                  onPressEnter={handleBuscar}
+                  placeholder="Entre com o RF"
+                />
+              </CustomFormItem>
+            </Col>
+            <Col xs={24} md={4}>
+              <CustomFormItem label={<span style={{ visibility: "hidden" }}>_</span>} labelCol={{ span: 24 }}>
+                <Button                  
+                  size="large"
+                  onClick={handleBuscar}
+                  disabled={!rf.trim()}
+                  style={{ width: "100%" }}
+                >
+                  Buscar usuário
+                </Button>
+              </CustomFormItem>
+            </Col>
+          </Row>
+
+          {erro && (
+            <Alert
+              type="error"
+              message={erro}
+              showIcon
+              style={{ marginTop: 16 }}
+            />
+          )}
+
+          {dadosUsuario && (
+            <>
+              <Row gutter={[16, 0]} style={{ marginTop: 32 }}>
+                <Col xs={24} md={12}>
+                  <CustomFormItem
+                    label={<FieldLabel>Nome</FieldLabel>}
+                    labelCol={{ span: 24 }}
+                  >
+                    <Input value={dadosUsuario.nome} disabled />
+                  </CustomFormItem>
+                </Col>
+                <Col xs={24} md={12}>
+                  <CustomFormItem
+                    label={<FieldLabel>E-mail</FieldLabel>}
+                    labelCol={{ span: 24 }}
+                  >
+                    <Input value={dadosUsuario.email} disabled />
+                  </CustomFormItem>
+                </Col>
+              </Row>
+
+              {erroAdicao && (
+                <Alert
+                  type="error"
+                  message={erroAdicao}
+                  showIcon
+                  style={{ marginTop: 8, marginBottom: 8 }}
+                />
+              )}
+
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 8 }}>
+                <Button
+                  size="large"
+                  onClick={() => navigate("/gerenciar/gerenciamento-usuarios")}
+                  disabled={criarUsuarioMutation.isPending}              
+                >
+                  Voltar
+                </Button>
+                <Button
+                  type="primary"
+                  size="large"
+                  onClick={handleAdicionar}
+                  loading={criarUsuarioMutation.isPending}             
+                >
+                  Adicionar usuário
+                </Button>
+              </div>
+            </>
+          )}
+        </ConteudoPagina>
+      </BaseTela>
+    </PageContainer>
+  );
+};
+
+export default AdicionarUsuarioTela;

--- a/src/pages/Gerenciar/AdicionarUsuario/hooks/usePostCriarUsuario.tsx
+++ b/src/pages/Gerenciar/AdicionarUsuario/hooks/usePostCriarUsuario.tsx
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { App } from "antd";
+import { postCriarUsuario } from "../../../../services/resources/usuarios";
+import type { ICriarUsuarioRequest } from "../../../../services/resources/usuarios";
+
+type UsePostCriarUsuarioOptions = {
+  onSuccess?: () => void;
+};
+
+export const usePostCriarUsuario = (options?: UsePostCriarUsuarioOptions) => {
+  const queryClient = useQueryClient();
+  const { notification } = App.useApp();
+
+  return useMutation({
+    mutationFn: (payload: ICriarUsuarioRequest) =>
+      postCriarUsuario(payload).response,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["getUsuariosComGrupos"] });
+      notification.success({
+        message: "Usuário Cadastrado",
+        description: "O usuário foi cadastrado com sucesso!",
+        placement: "top",
+        duration: 3.5,
+      });
+      options?.onSuccess?.();
+    },
+  });
+};

--- a/src/pages/Gerenciar/AdicionarUsuario/styles.ts
+++ b/src/pages/Gerenciar/AdicionarUsuario/styles.ts
@@ -1,0 +1,9 @@
+export {
+  PageContainer,
+  ConteudoPagina,
+  FieldLabel,
+  SearchButton,
+  ClearButton,
+  HeaderContainer,
+  ActionButton,
+} from "../../Processos/ConvocacaoCandidatos/style";

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,6 +20,7 @@ import RouteError from "./RouteError";
 import GerenciamentoVagasTela from "../pages/GerenciamentoVagas/GerenciamentoVagasTela";
 import EscolhaCandidatosTela from "../pages/EscolhaCandidatos/EscolhaCandidatosTela";
 import PermissaoUsuarioTela from "../pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela";
+import AdicionarUsuarioTela from "../pages/Gerenciar/AdicionarUsuario/AdicionarUsuarioTela";
 import CadastroParametrosTela from "../pages/Gerenciar/Parametros/CadastroParametrosTela";
 
 import DadosDoProcesso from "../pages/CriarEditarConvocacao/DadosDoProcesso";
@@ -154,11 +155,22 @@ const router = createBrowserRouter([
     errorElement: <RouteError />,
   },  
   {
-    path: "/gerenciar/permissao-usuario",
+    path: "/gerenciar/gerenciamento-usuarios",
     element: (
       <ProtectedRoute>
         <PermissionContextGuard model="group" permissaoDeExibirATELA="view_group">
-        <PermissaoUsuarioTela />
+          <PermissaoUsuarioTela />
+        </PermissionContextGuard>
+      </ProtectedRoute>
+    ),
+    errorElement: <RouteError />,
+  },
+  {
+    path: "/gerenciar/adicao-usuario",
+    element: (
+      <ProtectedRoute>
+        <PermissionContextGuard model="user" permissaoDeExibirATELA="add_user">
+          <AdicionarUsuarioTela />
         </PermissionContextGuard>
       </ProtectedRoute>
     ),

--- a/src/services/resources/usuarios/IUsuarios.ts
+++ b/src/services/resources/usuarios/IUsuarios.ts
@@ -10,3 +10,19 @@ export interface IAlterarSenhaRequest {
   nova_senha: string;
   confirmacao_nova_senha: string;
 }
+
+export interface IBuscarUsuarioEolRequest {
+  rf: string;
+}
+
+export interface IBuscarUsuarioEolResponse {
+  username: string;
+  nome: string;
+  email: string;
+}
+
+export interface ICriarUsuarioRequest {
+  username: string;
+  nome: string;
+  email: string;
+}

--- a/src/services/resources/usuarios/index.ts
+++ b/src/services/resources/usuarios/index.ts
@@ -1,12 +1,26 @@
 import type { AxiosRequestConfig } from "axios";
 import { appAxiosAdminUsuarios } from "../../axios";
-import type { IMeusDadosResponse, IAlterarSenhaRequest } from "./IUsuarios";
+import type {
+  IMeusDadosResponse,
+  IAlterarSenhaRequest,
+  IBuscarUsuarioEolRequest,
+  IBuscarUsuarioEolResponse,
+  ICriarUsuarioRequest,
+} from "./IUsuarios";
 
-export type { IMeusDadosResponse, IAlterarSenhaRequest };
+export type {
+  IMeusDadosResponse,
+  IAlterarSenhaRequest,
+  IBuscarUsuarioEolRequest,
+  IBuscarUsuarioEolResponse,
+  ICriarUsuarioRequest,
+};
 
 export const URL = {
   meusDados: () => `/api/v1/meus-dados/`,
   alterarSenha: () => `/api/v1/alterar-senha/`,
+  buscarUsuarioEol: () => `/api/v1/buscar-usuario-eol/`,
+  criarUsuario: () => `/api/v1/criar-usuario/`,
 };
 
 export const getMeusDados = (axiosRequestConfig?: AxiosRequestConfig) => {
@@ -30,6 +44,38 @@ export const postAlterarSenha = (
 
   const response = appAxiosAdminUsuarios
     .post<{ detail: string }>(URL.alterarSenha(), payload, {
+      signal,
+      ...axiosRequestConfig,
+    })
+    .then((response) => response.data);
+
+  return { response, abort };
+};
+
+export const postBuscarUsuarioEol = (
+  payload: IBuscarUsuarioEolRequest,
+  axiosRequestConfig?: AxiosRequestConfig
+) => {
+  const { signal, abort } = new AbortController();
+
+  const response = appAxiosAdminUsuarios
+    .post<IBuscarUsuarioEolResponse>(URL.buscarUsuarioEol(), payload, {
+      signal,
+      ...axiosRequestConfig,
+    })
+    .then((response) => response.data);
+
+  return { response, abort };
+};
+
+export const postCriarUsuario = (
+  payload: ICriarUsuarioRequest,
+  axiosRequestConfig?: AxiosRequestConfig
+) => {
+  const { signal, abort } = new AbortController();
+
+  const response = appAxiosAdminUsuarios
+    .post<{ detail: string; user: string }>(URL.criarUsuario(), payload, {
       signal,
       ...axiosRequestConfig,
     })


### PR DESCRIPTION
Implementa a tela de cadastro de novo usuário em Gerenciar > Gerenciamento
de usuários > Adicionar usuário, consumindo o EOL para obter os dados do
servidor a partir do RF informado.

## O que foi feito

- Nova página `AdicionarUsuarioTela` em `src/pages/Gerenciar/AdicionarUsuario/`
  com fluxo de busca por RF e confirmação de cadastro.
- Nova rota `/gerenciar/adicao-usuario` protegida pela permissão `add_user`
  (model `user`).
- Renomeação da rota de permissões para `/gerenciar/gerenciamento-usuarios`,
  alinhando com o novo breadcrumb.
- Service `usuarios` estendido com `postBuscarUsuarioEol` e `postCriarUsuario`,
  além das interfaces `IBuscarUsuarioEolRequest/Response` e `ICriarUsuarioRequest`.
- Hook `usePostCriarUsuario` para encapsular a mutação de criação.


[AB#148083](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148083)
[AB#148083](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148083)