### PR TITLE
feat(149042): adicionar tratamento de erros para atualizacoes de permissoes de usuario e aprimorar a funcionalidade modal.

### DIFF
--- a/src/pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela.tsx
@@ -19,6 +19,7 @@ import type {
   EditarPermissaoModalSavePayload,
   IPermissaoUsuarioRow,
 } from "../../../services/resources/permissoes/IPermissoes";
+import { PatchUsuario400Error } from "../../../services/resources/permissoes/IPermissoes";
 import { getGruposDisponiveisOptions, getUsuariosComGrupos } from "./hooks/getPermissaoUsuario";
 import { patchUsuario } from "./hooks/patchAtualizarPermissoesUsuarios";
 
@@ -269,29 +270,34 @@ const PermissaoUsuarioTela: React.FC = () => {
               return;
             }
 
+            const nextPermissoes = next?.permissoes || [];
+            const payload: any = { username, grupos: nextPermissoes };
+
+            const currentNome = (selectedUser?.nome ?? "").trim();
+            const nextNome = (next?.nome ?? "").trim();
+            if (next?.nome !== undefined && nextNome !== currentNome) {
+              payload.nome = nextNome;
+            }
+
+            const currentEmail = (selectedUser?.email ?? "").trim();
+            const nextEmail = (next?.email ?? "").trim();
+            if (next?.email !== undefined && nextEmail !== currentEmail) {
+              payload.email = nextEmail;
+            }
+
             try {
-              const nextPermissoes = next?.permissoes || [];
-              const payload: any = { username, grupos: nextPermissoes };
-
-              const currentNome = (selectedUser?.nome ?? "").trim();
-              const nextNome = (next?.nome ?? "").trim();
-              if (next?.nome !== undefined && nextNome !== currentNome) {
-                payload.nome = nextNome;
-              }
-
-              const currentEmail = (selectedUser?.email ?? "").trim();
-              const nextEmail = (next?.email ?? "").trim();
-              if (next?.email !== undefined && nextEmail !== currentEmail) {
-                payload.email = nextEmail;
-              }
-
               await patchUsuario(payload);
               setPermissaoSucessoNome(selectedUser?.nome || selectedUser?.login || "");
               setPermissaoSucessoOpen(true);
+              setModalOpen(false);
+              const vals = (control as any)?._formValues ?? {};
+              void handleSub(vals);
             } catch (e: any) {
+              if (e instanceof PatchUsuario400Error) {
+                throw e;
+              }
               console.error("Falha ao atualizar permissões do usuário:", e);
               message.error("Não foi possível salvar a permissão do usuário.");
-            } finally {
               setModalOpen(false);
               const vals = (control as any)?._formValues ?? {};
               void handleSub(vals);

--- a/src/pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela.tsx
@@ -19,7 +19,6 @@ import type {
   EditarPermissaoModalSavePayload,
   IPermissaoUsuarioRow,
 } from "../../../services/resources/permissoes/IPermissoes";
-import { PatchUsuario400Error } from "../../../services/resources/permissoes/IPermissoes";
 import { getGruposDisponiveisOptions, getUsuariosComGrupos } from "./hooks/getPermissaoUsuario";
 import { patchUsuario } from "./hooks/patchAtualizarPermissoesUsuarios";
 
@@ -285,23 +284,12 @@ const PermissaoUsuarioTela: React.FC = () => {
               payload.email = nextEmail;
             }
 
-            try {
-              await patchUsuario(payload);
-              setPermissaoSucessoNome(selectedUser?.nome || selectedUser?.login || "");
-              setPermissaoSucessoOpen(true);
-              setModalOpen(false);
-              const vals = (control as any)?._formValues ?? {};
-              void handleSub(vals);
-            } catch (e: any) {
-              if (e instanceof PatchUsuario400Error) {
-                throw e;
-              }
-              console.error("Falha ao atualizar permissões do usuário:", e);
-              message.error("Não foi possível salvar a permissão do usuário.");
-              setModalOpen(false);
-              const vals = (control as any)?._formValues ?? {};
-              void handleSub(vals);
-            }
+            await patchUsuario(payload);
+            setPermissaoSucessoNome(selectedUser?.nome || selectedUser?.login || "");
+            setPermissaoSucessoOpen(true);
+            setModalOpen(false);
+            const vals = (control as any)?._formValues ?? {};
+            void handleSub(vals);
           }}
         />
         <ConteudoPagina>

--- a/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { Button, Col, Input, Modal, Row, Select, Typography } from "antd";
 
 import { ClearButton } from "../../../Processos/ConvocacaoCandidatos/style";
-import type { EditarPermissaoModalProps } from "../../../../services/resources/permissoes/IPermissoes";
+import { CustomFormItem } from "../../../../components/FormStyle";
+import {
+  PatchUsuario400Error,
+  type EditarPermissaoModalProps,
+  type PatchUsuarioFieldErrors,
+} from "../../../../services/resources/permissoes/IPermissoes";
 
 const labelStyle: React.CSSProperties = {
   fontFamily: "Open Sans",
@@ -29,14 +34,34 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
   const [permissoes, setPermissoes] = React.useState<string[]>(data?.permissoes ?? []);
   const [nome, setNome] = React.useState<string>(data?.nome ?? "");
   const [email, setEmail] = React.useState<string>(data?.email ?? "");
+  const [errors, setErrors] = React.useState<PatchUsuarioFieldErrors>({});
+  const [saving, setSaving] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     setPermissoes(data?.permissoes ?? []);
     setNome(data?.nome ?? "");
     setEmail(data?.email ?? "");
+    setErrors({});
   }, [data?.permissoes, data?.nome, data?.email, open]);
 
   const isView = mode === "view";
+
+  const handleSalvar = async () => {
+    if (!onSave) return;
+    setSaving(true);
+    try {
+      await onSave({ permissoes, nome, email });
+      setErrors({});
+    } catch (err) {
+      if (err instanceof PatchUsuario400Error) {
+        setErrors(err.fieldErrors);
+        return;
+      }
+      throw err;
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <Modal
@@ -56,14 +81,11 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
             <Button
               size="large"
               type="primary"
+              loading={saving}
               style={{ height: 48, width: 200, marginTop: 0 }}
-              onClick={() =>
-                onSave?.({
-                  permissoes,
-                  nome,
-                  email,
-                })
-              }
+              onClick={() => {
+                void handleSalvar();
+              }}
             >
               Salvar permissão
             </Button>
@@ -88,13 +110,21 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
           {isView ? (
             <div style={{ ...valueStyle, marginTop: 12 }}>{data?.nome ?? ""}</div>
           ) : (
-            <Input
-              size="large"
-              value={nome}
-              onChange={(e) => setNome(e.target.value)}
-              style={{ marginTop: 12 }}
-              placeholder="Nome"
-            />
+            <CustomFormItem
+              style={{ marginTop: 12, marginBottom: 0 }}
+              validateStatus={errors.nome ? "error" : undefined}
+              help={errors.nome}
+            >
+              <Input
+                size="large"
+                value={nome}
+                onChange={(e) => {
+                  setNome(e.target.value);
+                  if (errors.nome) setErrors((prev) => ({ ...prev, nome: undefined }));
+                }}
+                placeholder="Nome"
+              />
+            </CustomFormItem>
           )}
         </Col>
         <Col span={8}>
@@ -102,13 +132,21 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
           {isView ? (
             <div style={{ ...valueStyle, marginTop: 12 }}>{data?.email ?? ""}</div>
           ) : (
-            <Input
-              size="large"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              style={{ marginTop: 12 }}
-              placeholder="E-mail"
-            />
+            <CustomFormItem
+              style={{ marginTop: 12, marginBottom: 0 }}
+              validateStatus={errors.email ? "error" : undefined}
+              help={errors.email}
+            >
+              <Input
+                size="large"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  if (errors.email) setErrors((prev) => ({ ...prev, email: undefined }));
+                }}
+                placeholder="E-mail"
+              />
+            </CustomFormItem>
           )}
         </Col>
 

--- a/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
@@ -1,13 +1,18 @@
 import React from "react";
-import { Button, Col, Input, Modal, Row, Select, Typography } from "antd";
+import { Button, Col, Input, message, Modal, Row, Select, Typography } from "antd";
+import axios from "axios";
 
 import { ClearButton } from "../../../Processos/ConvocacaoCandidatos/style";
 import { CustomFormItem } from "../../../../components/FormStyle";
-import {
-  PatchUsuario400Error,
-  type EditarPermissaoModalProps,
-  type PatchUsuarioFieldErrors,
-} from "../../../../services/resources/permissoes/IPermissoes";
+import type { EditarPermissaoModalProps } from "../../../../services/resources/permissoes/IPermissoes";
+
+type FieldErrors = { nome?: string; email?: string };
+
+function primeiraString(valor: unknown): string | undefined {
+  if (typeof valor === "string" && valor.trim()) return valor;
+  if (Array.isArray(valor) && typeof valor[0] === "string") return valor[0];
+  return undefined;
+}
 
 const labelStyle: React.CSSProperties = {
   fontFamily: "Open Sans",
@@ -34,7 +39,7 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
   const [permissoes, setPermissoes] = React.useState<string[]>(data?.permissoes ?? []);
   const [nome, setNome] = React.useState<string>(data?.nome ?? "");
   const [email, setEmail] = React.useState<string>(data?.email ?? "");
-  const [errors, setErrors] = React.useState<PatchUsuarioFieldErrors>({});
+  const [errors, setErrors] = React.useState<FieldErrors>({});
   const [saving, setSaving] = React.useState<boolean>(false);
 
   React.useEffect(() => {
@@ -53,11 +58,18 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
       await onSave({ permissoes, nome, email });
       setErrors({});
     } catch (err) {
-      if (err instanceof PatchUsuario400Error) {
-        setErrors(err.fieldErrors);
-        return;
+      if (axios.isAxiosError(err) && err.response?.status === 400) {
+        const body = err.response.data as { nome?: unknown; email?: unknown };
+        const next: FieldErrors = {
+          nome: primeiraString(body?.nome),
+          email: primeiraString(body?.email),
+        };
+        if (next.nome || next.email) {
+          setErrors(next);
+          return;
+        }
       }
-      throw err;
+      message.error("Não foi possível salvar a permissão do usuário.");
     } finally {
       setSaving(false);
     }

--- a/src/pages/Gerenciar/PermissaoUsuario/hooks/patchAtualizarPermissoesUsuarios.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/hooks/patchAtualizarPermissoesUsuarios.tsx
@@ -1,4 +1,53 @@
+import { notification } from "antd";
+import axios from "axios";
 import { API } from "../../../../services";
+import {
+  PatchUsuario400Error,
+  type PatchUsuarioFieldErrors,
+} from "../../../../services/resources/permissoes/IPermissoes";
+
+function primeiraStringDeCampo(valor: unknown): string | undefined {
+  if (typeof valor === "string" && valor.trim()) return valor;
+  if (Array.isArray(valor)) {
+    const txt = valor.find((v): v is string => typeof v === "string" && v.trim().length > 0);
+    return txt;
+  }
+  return undefined;
+}
+
+function extrairErrosPorCampo(data: unknown): PatchUsuarioFieldErrors {
+  if (!data || typeof data !== "object") return {};
+  const obj = data as Record<string, unknown>;
+  const result: PatchUsuarioFieldErrors = {};
+  const nome = primeiraStringDeCampo(obj.nome);
+  const email = primeiraStringDeCampo(obj.email);
+  if (nome) result.nome = nome;
+  if (email) result.email = email;
+  return result;
+}
+
+function extrairMensagemErro(data: unknown): string | undefined {
+  if (!data) return undefined;
+  if (typeof data === "string") return data;
+  if (typeof data !== "object") return undefined;
+
+  const obj = data as Record<string, unknown>;
+  const candidatos = [obj.detail, obj.message, obj.mensagem, obj.erro, obj.error];
+  for (const c of candidatos) {
+    if (typeof c === "string" && c.trim()) return c;
+  }
+
+  const partes: string[] = [];
+  for (const [campo, valor] of Object.entries(obj)) {
+    if (Array.isArray(valor)) {
+      const textos = valor.filter((v): v is string => typeof v === "string");
+      if (textos.length) partes.push(`${campo}: ${textos.join(" ")}`);
+    } else if (typeof valor === "string" && valor.trim()) {
+      partes.push(`${campo}: ${valor}`);
+    }
+  }
+  return partes.length ? partes.join(" | ") : undefined;
+}
 
 export async function patchUsuario(params: {
   username: string;
@@ -13,5 +62,26 @@ export async function patchUsuario(params: {
     ...rest,
   };
   const { response } = API.Permissoes.patchUsuario(payload);
-  return await response;
+  try {
+    console.log(response)
+    return await response;
+  } catch (error) {
+    console.error("Erro ao atualizar usuário:", error);
+    if (axios.isAxiosError(error) && error.response?.status === 400) {
+      const fieldErrors = extrairErrosPorCampo(error.response.data);
+      if (fieldErrors.nome || fieldErrors.email) {
+        throw new PatchUsuario400Error(fieldErrors, error.response.data);
+      }
+      const descricao =
+        extrairMensagemErro(error.response.data) ||
+        "Não foi possível atualizar o usuário. Verifique os dados informados e tente novamente.";
+      notification.error({
+        message: "Erro ao atualizar usuário",
+        description: descricao,
+        placement: "top",
+        duration: 4.5,
+      });
+    }
+    throw error;
+  }
 }

--- a/src/pages/Gerenciar/PermissaoUsuario/hooks/patchAtualizarPermissoesUsuarios.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/hooks/patchAtualizarPermissoesUsuarios.tsx
@@ -1,53 +1,4 @@
-import { notification } from "antd";
-import axios from "axios";
 import { API } from "../../../../services";
-import {
-  PatchUsuario400Error,
-  type PatchUsuarioFieldErrors,
-} from "../../../../services/resources/permissoes/IPermissoes";
-
-function primeiraStringDeCampo(valor: unknown): string | undefined {
-  if (typeof valor === "string" && valor.trim()) return valor;
-  if (Array.isArray(valor)) {
-    const txt = valor.find((v): v is string => typeof v === "string" && v.trim().length > 0);
-    return txt;
-  }
-  return undefined;
-}
-
-function extrairErrosPorCampo(data: unknown): PatchUsuarioFieldErrors {
-  if (!data || typeof data !== "object") return {};
-  const obj = data as Record<string, unknown>;
-  const result: PatchUsuarioFieldErrors = {};
-  const nome = primeiraStringDeCampo(obj.nome);
-  const email = primeiraStringDeCampo(obj.email);
-  if (nome) result.nome = nome;
-  if (email) result.email = email;
-  return result;
-}
-
-function extrairMensagemErro(data: unknown): string | undefined {
-  if (!data) return undefined;
-  if (typeof data === "string") return data;
-  if (typeof data !== "object") return undefined;
-
-  const obj = data as Record<string, unknown>;
-  const candidatos = [obj.detail, obj.message, obj.mensagem, obj.erro, obj.error];
-  for (const c of candidatos) {
-    if (typeof c === "string" && c.trim()) return c;
-  }
-
-  const partes: string[] = [];
-  for (const [campo, valor] of Object.entries(obj)) {
-    if (Array.isArray(valor)) {
-      const textos = valor.filter((v): v is string => typeof v === "string");
-      if (textos.length) partes.push(`${campo}: ${textos.join(" ")}`);
-    } else if (typeof valor === "string" && valor.trim()) {
-      partes.push(`${campo}: ${valor}`);
-    }
-  }
-  return partes.length ? partes.join(" | ") : undefined;
-}
 
 export async function patchUsuario(params: {
   username: string;
@@ -57,31 +8,6 @@ export async function patchUsuario(params: {
   is_active?: boolean;
 }) {
   const { username, ...rest } = params;
-  const payload = {
-    usuario: username,
-    ...rest,
-  };
-  const { response } = API.Permissoes.patchUsuario(payload);
-  try {
-    console.log(response)
-    return await response;
-  } catch (error) {
-    console.error("Erro ao atualizar usuário:", error);
-    if (axios.isAxiosError(error) && error.response?.status === 400) {
-      const fieldErrors = extrairErrosPorCampo(error.response.data);
-      if (fieldErrors.nome || fieldErrors.email) {
-        throw new PatchUsuario400Error(fieldErrors, error.response.data);
-      }
-      const descricao =
-        extrairMensagemErro(error.response.data) ||
-        "Não foi possível atualizar o usuário. Verifique os dados informados e tente novamente.";
-      notification.error({
-        message: "Erro ao atualizar usuário",
-        description: descricao,
-        placement: "top",
-        duration: 4.5,
-      });
-    }
-    throw error;
-  }
+  const { response } = API.Permissoes.patchUsuario({ usuario: username, ...rest });
+  return await response;
 }

--- a/src/services/resources/permissoes/IPermissoes.ts
+++ b/src/services/resources/permissoes/IPermissoes.ts
@@ -53,13 +53,29 @@ export interface EditarPermissaoModalSavePayload {
   email?: string;
 }
 
+export interface PatchUsuarioFieldErrors {
+  nome?: string;
+  email?: string;
+}
+
+export class PatchUsuario400Error extends Error {
+  fieldErrors: PatchUsuarioFieldErrors;
+  raw: unknown;
+  constructor(fieldErrors: PatchUsuarioFieldErrors, raw: unknown) {
+    super("PatchUsuario400Error");
+    this.name = "PatchUsuario400Error";
+    this.fieldErrors = fieldErrors;
+    this.raw = raw;
+  }
+}
+
 export interface EditarPermissaoModalProps {
   open: boolean;
   mode: EditarPermissaoModalMode;
   data?: EditarPermissaoModalData;
   permissoesOptions?: Array<{ value: string; label: string }>;
   onClose: () => void;
-  onSave?: (next?: EditarPermissaoModalSavePayload) => void;
+  onSave?: (next?: EditarPermissaoModalSavePayload) => void | Promise<void>;
 }
 
 export interface IPermissaoUsuarioRow {

--- a/src/services/resources/permissoes/IPermissoes.ts
+++ b/src/services/resources/permissoes/IPermissoes.ts
@@ -53,22 +53,6 @@ export interface EditarPermissaoModalSavePayload {
   email?: string;
 }
 
-export interface PatchUsuarioFieldErrors {
-  nome?: string;
-  email?: string;
-}
-
-export class PatchUsuario400Error extends Error {
-  fieldErrors: PatchUsuarioFieldErrors;
-  raw: unknown;
-  constructor(fieldErrors: PatchUsuarioFieldErrors, raw: unknown) {
-    super("PatchUsuario400Error");
-    this.name = "PatchUsuario400Error";
-    this.fieldErrors = fieldErrors;
-    this.raw = raw;
-  }
-}
-
 export interface EditarPermissaoModalProps {
   open: boolean;
   mode: EditarPermissaoModalMode;


### PR DESCRIPTION
Ao editar um usuário em Gerenciar → Permissão de Usuário, o backend pode retornar HTTP 400 com erros de validação por campo (ex.: nome em branco, email inválido). Antes, esse retorno disparava apenas uma notification global do antd e o modal fechava no finally, fazendo o usuário perder o que havia preenchido e sem saber qual campo estava incorreto.

Mudanças
Mapeamento por campo no hook patchUsuario — quando o 400 trouxer nome e/ou email, lança PatchUsuario400Error (nova classe) carregando os erros estruturados; nesse caso, a notification global não é disparada. 400 sem mapeamento de campo continuam exibindo a notification como antes.
Tipos compartilhados em services/resources/permissoes/IPermissoes.ts: PatchUsuarioFieldErrors e PatchUsuario400Error. onSave do modal passou a aceitar Promise<void>.
EditarPermissaoModal: campos nome e email agora são renderizados com CustomFormItem usando validateStatus/help para mostrar a mensagem inline abaixo do input. O botão "Salvar permissão" virou async com estado loading, captura o PatchUsuario400Error e exibe os erros sem fechar o modal. Editar o campo limpa o erro daquele campo.
PermissaoUsuarioTela: o modal só fecha em sucesso ou erros não-validacionais. Em PatchUsuario400Error, o erro é re-lançado para o modal tratar — o usuário permanece no modal com os valores preservados para corrigir e tentar novamente.


[AB#149044](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149044)
[AB#148945](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148945)