### PR TITLE
feat(149043):modal alterar email em Meus Dados

### DIFF
--- a/src/pages/MeusDados/MeusDadosTela.tsx
+++ b/src/pages/MeusDados/MeusDadosTela.tsx
@@ -3,6 +3,7 @@ import { Button, Avatar, Spin } from "antd";
 import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
 import BaseTela from "../Base/BaseTela";
 import AlterarSenhaModal from "./components/AlterarSenhaModal";
+import AlterarEmailModal from "./components/AlterarEmailModal";
 import { useGetMeusDados } from "./hooks/useGetMeusDados";
 import { StandardInput } from "../../components/EstilosCompartilhados";
 import {
@@ -17,6 +18,7 @@ import {
 
 const MeusDadosTela: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isEmailModalOpen, setIsEmailModalOpen] = useState(false);
   const { data, isLoading } = useGetMeusDados();
 
   const nomeCompleto = data?.nome_completo ?? "";
@@ -55,6 +57,9 @@ const MeusDadosTela: React.FC = () => {
               <FieldLabel>E-mail</FieldLabel>
               <FieldRow>
                 <StandardInput value={email} disabled style={{ flex: 1 }} />
+                <Button onClick={() => setIsEmailModalOpen(true)}>
+                  Alterar e-mail
+                </Button>
               </FieldRow>
             </div>
 
@@ -89,6 +94,11 @@ const MeusDadosTela: React.FC = () => {
       <AlterarSenhaModal
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
+      />
+
+      <AlterarEmailModal
+        open={isEmailModalOpen}
+        onClose={() => setIsEmailModalOpen(false)}
       />
     </BaseTela>
   );

--- a/src/pages/MeusDados/components/AlterarEmailModal.styles.ts
+++ b/src/pages/MeusDados/components/AlterarEmailModal.styles.ts
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import { Typography } from "antd";
+
+const { Text } = Typography;
+
+export const ModalTitleStyled = styled.div`
+  font-family: "Open Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #1c1d22;
+  margin-bottom: 1.5rem;
+`;
+
+export const FieldLabel = styled(Text)`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #161616;
+  display: block;
+  margin-bottom: 0.25rem;
+`;
+
+export const FieldWrapper = styled.div`
+  margin-bottom: 1rem;
+`;
+
+export const ErrorText = styled(Text)`
+  color: #ff4d4f;
+  font-size: 0.75rem;
+  display: block;
+  margin-top: 0.25rem;
+`;
+
+export const ButtonsContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+`;

--- a/src/pages/MeusDados/components/AlterarEmailModal.tsx
+++ b/src/pages/MeusDados/components/AlterarEmailModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Modal, Button, Alert, Form } from "antd";
 import { useAlterarEmail } from "../hooks/usePostAlterarEmail";
 import { StandardInput } from "../../../components/EstilosCompartilhados";
@@ -19,44 +19,21 @@ interface AlterarEmailFormValues {
 
 const AlterarEmailModal: React.FC<AlterarEmailModalProps> = ({ open, onClose }) => {
   const [form] = Form.useForm<AlterarEmailFormValues>();
-  const [apiError, setApiError] = useState<string | null>(null);
 
   const { mutate, isPending } = useAlterarEmail();
 
   const handleClose = () => {
     form.resetFields();
-    setApiError(null);
     onClose();
   };
 
   const handleSalvar = async () => {
-    setApiError(null);
     try {
       const values = await form.validateFields();
 
       mutate(
         { novo_email: values.novo_email.trim() },
-        {
-          onSuccess: () => {
-            handleClose();
-          },
-          onError: (error: any) => {
-            const data = error?.response?.data;
-            const fieldError = Array.isArray(data?.novo_email)
-              ? data.novo_email[0]
-              : undefined;
-            const detail =
-              typeof data?.detail === "string" ? data.detail : undefined;
-            const mensagem =
-              fieldError ?? detail ?? "Erro ao alterar o e-mail. Tente novamente.";
-
-            if (fieldError) {
-              form.setFields([{ name: "novo_email", errors: [mensagem] }]);
-            } else {
-              setApiError(mensagem);
-            }
-          },
-        }
+        { onSuccess: handleClose }
       );
     } catch {
       // validateFields já exibe os erros nos campos
@@ -109,15 +86,6 @@ const AlterarEmailModal: React.FC<AlterarEmailModalProps> = ({ open, onClose }) 
           />
         </Form.Item>
       </Form>
-
-      {apiError && (
-        <Alert
-          type="error"
-          showIcon={false}
-          message={apiError}
-          style={{ marginTop: "1rem", textAlign: "center", fontWeight: 600 }}
-        />
-      )}
 
       <Alert
         type="info"

--- a/src/pages/MeusDados/components/AlterarEmailModal.tsx
+++ b/src/pages/MeusDados/components/AlterarEmailModal.tsx
@@ -28,16 +28,14 @@ const AlterarEmailModal: React.FC<AlterarEmailModalProps> = ({ open, onClose }) 
   };
 
   const handleSalvar = async () => {
-    try {
-      const values = await form.validateFields();
 
-      mutate(
-        { novo_email: values.novo_email.trim() },
-        { onSuccess: handleClose }
-      );
-    } catch {
-      // validateFields já exibe os erros nos campos
-    }
+  const values = await form.validateFields();
+
+  mutate(
+    { novo_email: values.novo_email.trim() },
+    { onSuccess: handleClose }
+  );
+
   };
 
   return (

--- a/src/pages/MeusDados/components/AlterarEmailModal.tsx
+++ b/src/pages/MeusDados/components/AlterarEmailModal.tsx
@@ -1,0 +1,181 @@
+import React, { useState } from "react";
+import { App, Modal, Button, Alert } from "antd";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAlterarEmail } from "../hooks/usePostAlterarEmail";
+import { StandardInput } from "../../../components/EstilosCompartilhados";
+import {
+  ModalTitleStyled,
+  FieldLabel,
+  FieldWrapper,
+  ErrorText,
+  ButtonsContainer,
+} from "./AlterarEmailModal.styles";
+
+interface AlterarEmailModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface FormState {
+  novo_email: string;
+  confirmacao_novo_email: string;
+}
+
+interface FormErrors {
+  novo_email?: string;
+  confirmacao_novo_email?: string;
+}
+
+const REGEX_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const AlterarEmailModal: React.FC<AlterarEmailModalProps> = ({ open, onClose }) => {
+  const [form, setForm] = useState<FormState>({
+    novo_email: "",
+    confirmacao_novo_email: "",
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const { notification } = App.useApp();
+  const { mutate, isPending } = useAlterarEmail();
+  const queryClient = useQueryClient();
+
+  const handleClose = () => {
+    setForm({ novo_email: "", confirmacao_novo_email: "" });
+    setErrors({});
+    setApiError(null);
+    onClose();
+  };
+
+  const validate = (): boolean => {
+    const newErrors: FormErrors = {};
+
+    const novoEmail = form.novo_email.trim();
+    const confirmacao = form.confirmacao_novo_email.trim();
+
+    if (!novoEmail) {
+      newErrors.novo_email = "Campo obrigatório.";
+    } else if (!REGEX_EMAIL.test(novoEmail)) {
+      newErrors.novo_email = "Informe um e-mail válido.";
+    }
+
+    if (!confirmacao) {
+      newErrors.confirmacao_novo_email = "Campo obrigatório.";
+    } else if (novoEmail !== confirmacao) {
+      newErrors.confirmacao_novo_email = "Os e-mails não conferem.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSalvar = () => {
+    setErrors({});
+    setApiError(null);
+    if (!validate()) return;
+
+    mutate(
+      { novo_email: form.novo_email.trim() },
+      {
+        onSuccess: () => {
+          notification.success({
+            message: "E-mail Alterado",
+            description: "O e-mail foi alterado com sucesso!",
+            placement: "top",
+            duration: 3.5,
+          });
+          queryClient.invalidateQueries({ queryKey: ["meus-dados"] });
+          handleClose();
+        },
+        onError: (error: any) => {
+          const data = error?.response?.data;
+          const fieldError = Array.isArray(data?.novo_email)
+            ? data.novo_email[0]
+            : undefined;
+          const detail =
+            typeof data?.detail === "string" ? data.detail : undefined;
+          const mensagem =
+            fieldError ?? detail ?? "Erro ao alterar o e-mail. Tente novamente.";
+
+          if (fieldError) {
+            setErrors((prev) => ({ ...prev, novo_email: mensagem }));
+          } else {
+            setApiError(mensagem);
+          }
+        },
+      }
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={handleClose}
+      footer={null}
+      width={520}
+      centered
+      destroyOnHidden
+      title={<ModalTitleStyled>Alterar e-mail</ModalTitleStyled>}
+    >
+      <FieldWrapper>
+        <FieldLabel>Novo e-mail*</FieldLabel>
+        <StandardInput
+          type="email"
+          placeholder="Digite o novo e-mail"
+          value={form.novo_email}
+          onChange={(e) =>
+            setForm((prev) => ({ ...prev, novo_email: e.target.value }))
+          }
+          status={errors.novo_email ? "error" : undefined}
+        />
+        {errors.novo_email && <ErrorText>{errors.novo_email}</ErrorText>}
+      </FieldWrapper>
+
+      <FieldWrapper>
+        <FieldLabel>Confirmação do novo e-mail*</FieldLabel>
+        <StandardInput
+          type="email"
+          placeholder="Digite o novo e-mail novamente"
+          value={form.confirmacao_novo_email}
+          onChange={(e) =>
+            setForm((prev) => ({
+              ...prev,
+              confirmacao_novo_email: e.target.value,
+            }))
+          }
+          status={errors.confirmacao_novo_email ? "error" : undefined}
+        />
+        {errors.confirmacao_novo_email && (
+          <ErrorText>{errors.confirmacao_novo_email}</ErrorText>
+        )}
+      </FieldWrapper>
+
+      {apiError && (
+        <Alert
+          type="error"
+          showIcon={false}
+          message={apiError}
+          style={{ marginTop: "1rem", textAlign: "center", fontWeight: 600 }}
+        />
+      )}
+
+      <Alert
+        type="info"
+        showIcon={false}
+        message="Importante: Ao alterar a seu e-mail, ele se tornará padrão em todos os sistemas da SME aos quais você já possui acesso."
+        style={{ marginTop: "1rem", fontSize: "0.8125rem" }}
+      />
+
+      <ButtonsContainer>
+        <Button onClick={handleClose} disabled={isPending}>
+          Cancelar
+        </Button>
+        <Button type="primary" onClick={handleSalvar} loading={isPending}>
+          Confirmar
+        </Button>
+      </ButtonsContainer>
+    </Modal>
+  );
+};
+
+export default AlterarEmailModal;

--- a/src/pages/MeusDados/components/AlterarEmailModal.tsx
+++ b/src/pages/MeusDados/components/AlterarEmailModal.tsx
@@ -1,13 +1,9 @@
 import React, { useState } from "react";
-import { App, Modal, Button, Alert } from "antd";
-import { useQueryClient } from "@tanstack/react-query";
+import { Modal, Button, Alert, Form } from "antd";
 import { useAlterarEmail } from "../hooks/usePostAlterarEmail";
 import { StandardInput } from "../../../components/EstilosCompartilhados";
 import {
   ModalTitleStyled,
-  FieldLabel,
-  FieldWrapper,
-  ErrorText,
   ButtonsContainer,
 } from "./AlterarEmailModal.styles";
 
@@ -16,95 +12,55 @@ interface AlterarEmailModalProps {
   onClose: () => void;
 }
 
-interface FormState {
+interface AlterarEmailFormValues {
   novo_email: string;
   confirmacao_novo_email: string;
 }
 
-interface FormErrors {
-  novo_email?: string;
-  confirmacao_novo_email?: string;
-}
-
-const REGEX_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 const AlterarEmailModal: React.FC<AlterarEmailModalProps> = ({ open, onClose }) => {
-  const [form, setForm] = useState<FormState>({
-    novo_email: "",
-    confirmacao_novo_email: "",
-  });
-  const [errors, setErrors] = useState<FormErrors>({});
+  const [form] = Form.useForm<AlterarEmailFormValues>();
   const [apiError, setApiError] = useState<string | null>(null);
 
-  const { notification } = App.useApp();
   const { mutate, isPending } = useAlterarEmail();
-  const queryClient = useQueryClient();
 
   const handleClose = () => {
-    setForm({ novo_email: "", confirmacao_novo_email: "" });
-    setErrors({});
+    form.resetFields();
     setApiError(null);
     onClose();
   };
 
-  const validate = (): boolean => {
-    const newErrors: FormErrors = {};
-
-    const novoEmail = form.novo_email.trim();
-    const confirmacao = form.confirmacao_novo_email.trim();
-
-    if (!novoEmail) {
-      newErrors.novo_email = "Campo obrigatório.";
-    } else if (!REGEX_EMAIL.test(novoEmail)) {
-      newErrors.novo_email = "Informe um e-mail válido.";
-    }
-
-    if (!confirmacao) {
-      newErrors.confirmacao_novo_email = "Campo obrigatório.";
-    } else if (novoEmail !== confirmacao) {
-      newErrors.confirmacao_novo_email = "Os e-mails não conferem.";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSalvar = () => {
-    setErrors({});
+  const handleSalvar = async () => {
     setApiError(null);
-    if (!validate()) return;
+    try {
+      const values = await form.validateFields();
 
-    mutate(
-      { novo_email: form.novo_email.trim() },
-      {
-        onSuccess: () => {
-          notification.success({
-            message: "E-mail Alterado",
-            description: "O e-mail foi alterado com sucesso!",
-            placement: "top",
-            duration: 3.5,
-          });
-          queryClient.invalidateQueries({ queryKey: ["meus-dados"] });
-          handleClose();
-        },
-        onError: (error: any) => {
-          const data = error?.response?.data;
-          const fieldError = Array.isArray(data?.novo_email)
-            ? data.novo_email[0]
-            : undefined;
-          const detail =
-            typeof data?.detail === "string" ? data.detail : undefined;
-          const mensagem =
-            fieldError ?? detail ?? "Erro ao alterar o e-mail. Tente novamente.";
+      mutate(
+        { novo_email: values.novo_email.trim() },
+        {
+          onSuccess: () => {
+            handleClose();
+          },
+          onError: (error: any) => {
+            const data = error?.response?.data;
+            const fieldError = Array.isArray(data?.novo_email)
+              ? data.novo_email[0]
+              : undefined;
+            const detail =
+              typeof data?.detail === "string" ? data.detail : undefined;
+            const mensagem =
+              fieldError ?? detail ?? "Erro ao alterar o e-mail. Tente novamente.";
 
-          if (fieldError) {
-            setErrors((prev) => ({ ...prev, novo_email: mensagem }));
-          } else {
-            setApiError(mensagem);
-          }
-        },
-      }
-    );
+            if (fieldError) {
+              form.setFields([{ name: "novo_email", errors: [mensagem] }]);
+            } else {
+              setApiError(mensagem);
+            }
+          },
+        }
+      );
+    } catch {
+      // validateFields já exibe os erros nos campos
+    }
   };
 
   return (
@@ -117,38 +73,42 @@ const AlterarEmailModal: React.FC<AlterarEmailModalProps> = ({ open, onClose }) 
       destroyOnHidden
       title={<ModalTitleStyled>Alterar e-mail</ModalTitleStyled>}
     >
-      <FieldWrapper>
-        <FieldLabel>Novo e-mail*</FieldLabel>
-        <StandardInput
-          type="email"
-          placeholder="Digite o novo e-mail"
-          value={form.novo_email}
-          onChange={(e) =>
-            setForm((prev) => ({ ...prev, novo_email: e.target.value }))
-          }
-          status={errors.novo_email ? "error" : undefined}
-        />
-        {errors.novo_email && <ErrorText>{errors.novo_email}</ErrorText>}
-      </FieldWrapper>
+      <Form form={form} layout="vertical" requiredMark={false}>
+        <Form.Item
+          name="novo_email"
+          label="Novo e-mail"
+          required
+          rules={[
+            { required: true, message: "Campo obrigatório." },
+            { type: "email", message: "Informe um e-mail válido." },
+          ]}
+        >
+          <StandardInput type="email" placeholder="Digite o novo e-mail" />
+        </Form.Item>
 
-      <FieldWrapper>
-        <FieldLabel>Confirmação do novo e-mail*</FieldLabel>
-        <StandardInput
-          type="email"
-          placeholder="Digite o novo e-mail novamente"
-          value={form.confirmacao_novo_email}
-          onChange={(e) =>
-            setForm((prev) => ({
-              ...prev,
-              confirmacao_novo_email: e.target.value,
-            }))
-          }
-          status={errors.confirmacao_novo_email ? "error" : undefined}
-        />
-        {errors.confirmacao_novo_email && (
-          <ErrorText>{errors.confirmacao_novo_email}</ErrorText>
-        )}
-      </FieldWrapper>
+        <Form.Item
+          name="confirmacao_novo_email"
+          label="Confirmação do novo e-mail"
+          required
+          dependencies={["novo_email"]}
+          rules={[
+            { required: true, message: "Campo obrigatório." },
+            ({ getFieldValue }) => ({
+              validator(_, value) {
+                if (!value || getFieldValue("novo_email") === value) {
+                  return Promise.resolve();
+                }
+                return Promise.reject(new Error("Os e-mails não conferem."));
+              },
+            }),
+          ]}
+        >
+          <StandardInput
+            type="email"
+            placeholder="Digite o novo e-mail novamente"
+          />
+        </Form.Item>
+      </Form>
 
       {apiError && (
         <Alert

--- a/src/pages/MeusDados/components/AlterarSenhaModal.tsx
+++ b/src/pages/MeusDados/components/AlterarSenhaModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react";
-import { Modal, Button, Alert, message, Row, Col } from "antd";
+import { App, Modal, Button, Alert, Row, Col } from "antd";
 import { EyeInvisibleOutlined, EyeOutlined, CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
 import { useAlterarSenha } from "../hooks/usePostAlterarSenha";
 import { StandardInput } from "../../../components/EstilosCompartilhados";
@@ -90,6 +90,7 @@ const AlterarSenhaModal: React.FC<AlterarSenhaModalProps> = ({ open, onClose }) 
     ];
   }, [form.nova_senha, senhaDigitada]);
 
+  const { notification } = App.useApp();
   const { mutate, isPending } = useAlterarSenha();
 
   const handleClose = () => {
@@ -148,7 +149,12 @@ const AlterarSenhaModal: React.FC<AlterarSenhaModalProps> = ({ open, onClose }) 
 
     mutate(form, {
       onSuccess: () => {
-        message.success("Senha alterada com sucesso!");
+        notification.success({
+          message: "Senha Alterada",
+          description: "A senha foi alterada com sucesso!",
+          placement: "top",
+          duration: 3.5,
+        });
         handleClose();
       },
       onError: (error: any) => {

--- a/src/pages/MeusDados/hooks/usePostAlterarEmail.tsx
+++ b/src/pages/MeusDados/hooks/usePostAlterarEmail.tsx
@@ -1,10 +1,23 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { App } from "antd";
 import { postAlterarEmail } from "../../../services/resources/usuarios";
 import type { IAlterarEmailRequest } from "../../../services/resources/usuarios";
 
 export const useAlterarEmail = () => {
+  const queryClient = useQueryClient();
+  const { notification } = App.useApp();
+
   return useMutation({
     mutationFn: (payload: IAlterarEmailRequest) =>
       postAlterarEmail(payload).response,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["meus-dados"] });
+      notification.success({
+        message: "E-mail Alterado",
+        description: "O e-mail foi alterado com sucesso!",
+        placement: "top",
+        duration: 3.5,
+      });
+    },
   });
 };

--- a/src/pages/MeusDados/hooks/usePostAlterarEmail.tsx
+++ b/src/pages/MeusDados/hooks/usePostAlterarEmail.tsx
@@ -19,5 +19,22 @@ export const useAlterarEmail = () => {
         duration: 3.5,
       });
     },
+    onError: (error: any) => {
+      const data = error?.response?.data;
+      const fieldError = Array.isArray(data?.novo_email)
+        ? data.novo_email[0]
+        : undefined;
+      const detail =
+        typeof data?.detail === "string" ? data.detail : undefined;
+      const mensagem =
+        fieldError ?? detail ?? "Erro ao alterar o e-mail. Tente novamente.";
+
+      notification.error({
+        message: "Erro ao alterar e-mail",
+        description: mensagem,
+        placement: "top",
+        duration: 3.5,
+      });
+    },
   });
 };

--- a/src/pages/MeusDados/hooks/usePostAlterarEmail.tsx
+++ b/src/pages/MeusDados/hooks/usePostAlterarEmail.tsx
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { postAlterarEmail } from "../../../services/resources/usuarios";
+import type { IAlterarEmailRequest } from "../../../services/resources/usuarios";
+
+export const useAlterarEmail = () => {
+  return useMutation({
+    mutationFn: (payload: IAlterarEmailRequest) =>
+      postAlterarEmail(payload).response,
+  });
+};

--- a/src/services/resources/usuarios/IUsuarios.ts
+++ b/src/services/resources/usuarios/IUsuarios.ts
@@ -11,6 +11,10 @@ export interface IAlterarSenhaRequest {
   confirmacao_nova_senha: string;
 }
 
+export interface IAlterarEmailRequest {
+  novo_email: string;
+}
+
 export interface IBuscarUsuarioEolRequest {
   rf: string;
 }

--- a/src/services/resources/usuarios/index.ts
+++ b/src/services/resources/usuarios/index.ts
@@ -3,6 +3,7 @@ import { appAxiosAdminUsuarios } from "../../axios";
 import type {
   IMeusDadosResponse,
   IAlterarSenhaRequest,
+  IAlterarEmailRequest,
   IBuscarUsuarioEolRequest,
   IBuscarUsuarioEolResponse,
   ICriarUsuarioRequest,
@@ -11,6 +12,7 @@ import type {
 export type {
   IMeusDadosResponse,
   IAlterarSenhaRequest,
+  IAlterarEmailRequest,
   IBuscarUsuarioEolRequest,
   IBuscarUsuarioEolResponse,
   ICriarUsuarioRequest,
@@ -19,6 +21,7 @@ export type {
 export const URL = {
   meusDados: () => `/api/v1/meus-dados/`,
   alterarSenha: () => `/api/v1/alterar-senha/`,
+  alterarEmail: () => `/api/v1/alterar-email/`,
   buscarUsuarioEol: () => `/api/v1/buscar-usuario-eol/`,
   criarUsuario: () => `/api/v1/criar-usuario/`,
 };
@@ -44,6 +47,22 @@ export const postAlterarSenha = (
 
   const response = appAxiosAdminUsuarios
     .post<{ detail: string }>(URL.alterarSenha(), payload, {
+      signal,
+      ...axiosRequestConfig,
+    })
+    .then((response) => response.data);
+
+  return { response, abort };
+};
+
+export const postAlterarEmail = (
+  payload: IAlterarEmailRequest,
+  axiosRequestConfig?: AxiosRequestConfig
+) => {
+  const { signal, abort } = new AbortController();
+
+  const response = appAxiosAdminUsuarios
+    .post<{ detail: string }>(URL.alterarEmail(), payload, {
       signal,
       ...axiosRequestConfig,
     })


### PR DESCRIPTION
## Resumo

Integra o front com o endpoint `POST /api/v1/alterar-email/` permitindo que o usuário altere seu próprio e-mail pela tela **Meus Dados**, seguindo o mesmo padrão visual e de validação do "Alterar senha" já existente.

## Mudanças

- **Novo modal `AlterarEmailModal`** acionado por botão "Alterar e-mail" ao lado do input de e-mail em `MeusDadosTela`.
- **Dois campos** ("Novo e-mail" + "Confirmação do novo e-mail") com validação client-side:
  - Campos obrigatórios.
  - Formato de e-mail válido (regex).
  - Confirmação deve ser idêntica ao novo e-mail.
- **Envio ao backend** apenas com `{ novo_email }`, conforme contrato do serializer.
- **Tratamento de erros** que cobre os dois shapes 400 da API:
  - Erro de field do DRF (`{ "novo_email": ["..."] }`) → mensagem inline abaixo do campo, com input em vermelho.
  - Erro com `detail` (falha do SME Integração) → `<Alert>` no rodapé do modal.
  - Fallback genérico para resposta inesperada / network.
- **Notificação de sucesso** via `notification.success` (`App.useApp()`), com título "E-mail Alterado" e descrição, padronizando com `usePostCriarUsuario`. Após sucesso, `invalidateQueries(["meus-dados"])` atualiza o e-mail exibido na tela automaticamente.
- **Ajuste no `AlterarSenhaModal`**: troca o `message.success` antigo por `notification.success` no mesmo padrão, para manter consistência entre "Alterar senha" e "Alterar e-mail".


[AB#149044](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149044)
[AB#149043](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149043)
[AB#149046](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149046)