### PR TITLE
feat(149042): validacao no front

### DIFF
--- a/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
@@ -1,18 +1,8 @@
 import React from "react";
-import { Button, Col, Input, message, Modal, Row, Select, Typography } from "antd";
-import axios from "axios";
+import { Button, Col, Form, Input, Modal, Row, Select, Typography } from "antd";
 
 import { ClearButton } from "../../../Processos/ConvocacaoCandidatos/style";
-import { CustomFormItem } from "../../../../components/FormStyle";
 import type { EditarPermissaoModalProps } from "../../../../services/resources/permissoes/IPermissoes";
-
-type FieldErrors = { nome?: string; email?: string };
-
-function primeiraString(valor: unknown): string | undefined {
-  if (typeof valor === "string" && valor.trim()) return valor;
-  if (Array.isArray(valor) && typeof valor[0] === "string") return valor[0];
-  return undefined;
-}
 
 const labelStyle: React.CSSProperties = {
   fontFamily: "Open Sans",
@@ -36,44 +26,22 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
   onClose,
   onSave,
 }) => {
+  const [form] = Form.useForm<{ nome: string; email: string }>();
   const [permissoes, setPermissoes] = React.useState<string[]>(data?.permissoes ?? []);
-  const [nome, setNome] = React.useState<string>(data?.nome ?? "");
-  const [email, setEmail] = React.useState<string>(data?.email ?? "");
-  const [errors, setErrors] = React.useState<FieldErrors>({});
-  const [saving, setSaving] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    setPermissoes(data?.permissoes ?? []);
-    setNome(data?.nome ?? "");
-    setEmail(data?.email ?? "");
-    setErrors({});
-  }, [data?.permissoes, data?.nome, data?.email, open]);
+    if (open) {
+      setPermissoes(data?.permissoes ?? []);
+      form.setFieldsValue({
+        nome: data?.nome ?? "",
+        email: data?.email ?? "",
+      });
+    } else {
+      form.resetFields();
+    }
+  }, [open, data?.permissoes, data?.nome, data?.email, form]);
 
   const isView = mode === "view";
-
-  const handleSalvar = async () => {
-    if (!onSave) return;
-    setSaving(true);
-    try {
-      await onSave({ permissoes, nome, email });
-      setErrors({});
-    } catch (err) {
-      if (axios.isAxiosError(err) && err.response?.status === 400) {
-        const body = err.response.data as { nome?: unknown; email?: unknown };
-        const next: FieldErrors = {
-          nome: primeiraString(body?.nome),
-          email: primeiraString(body?.email),
-        };
-        if (next.nome || next.email) {
-          setErrors(next);
-          return;
-        }
-      }
-      message.error("Não foi possível salvar a permissão do usuário.");
-    } finally {
-      setSaving(false);
-    }
-  };
 
   return (
     <Modal
@@ -93,10 +61,18 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
             <Button
               size="large"
               type="primary"
-              loading={saving}
               style={{ height: 48, width: 200, marginTop: 0 }}
-              onClick={() => {
-                void handleSalvar();
+              onClick={async () => {
+                try {
+                  const values = await form.validateFields();
+                  onSave?.({
+                    permissoes,
+                    nome: values.nome,
+                    email: values.email,
+                  });
+                } catch {
+                  // validateFields lança quando há erros; o Form já exibe as mensagens
+                }
               }}
             >
               Salvar permissão
@@ -112,80 +88,71 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
         footer: { padding: "20px 24px" },
       }}
     >
-      <Row gutter={[32, 24]} style={{ marginTop: 8 }}>
-        <Col span={6}>
-          <div style={labelStyle}>Login (RF)</div>
-          <div style={{ ...valueStyle, marginTop: 12 }}>{data?.login ?? ""}</div>
-        </Col>
-        <Col span={10}>
-          <div style={labelStyle}>Nome</div>
-          {isView ? (
-            <div style={{ ...valueStyle, marginTop: 12 }}>{data?.nome ?? ""}</div>
-          ) : (
-            <CustomFormItem
-              style={{ marginTop: 12, marginBottom: 0 }}
-              validateStatus={errors.nome ? "error" : undefined}
-              help={errors.nome}
-            >
-              <Input
-                size="large"
-                value={nome}
-                onChange={(e) => {
-                  setNome(e.target.value);
-                  if (errors.nome) setErrors((prev) => ({ ...prev, nome: undefined }));
-                }}
-                placeholder="Nome"
-              />
-            </CustomFormItem>
-          )}
-        </Col>
-        <Col span={8}>
-          <div style={labelStyle}>E-mail</div>
-          {isView ? (
-            <div style={{ ...valueStyle, marginTop: 12 }}>{data?.email ?? ""}</div>
-          ) : (
-            <CustomFormItem
-              style={{ marginTop: 12, marginBottom: 0 }}
-              validateStatus={errors.email ? "error" : undefined}
-              help={errors.email}
-            >
-              <Input
-                size="large"
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                  if (errors.email) setErrors((prev) => ({ ...prev, email: undefined }));
-                }}
-                placeholder="E-mail"
-              />
-            </CustomFormItem>
-          )}
-        </Col>
+      <Form form={form} layout="vertical" requiredMark={false} component={false}>
+        <Row gutter={[32, 24]} style={{ marginTop: 8 }}>
+          <Col span={6}>
+            <div style={labelStyle}>Login (RF)</div>
+            <div style={{ ...valueStyle, marginTop: 12 }}>{data?.login ?? ""}</div>
+          </Col>
+          <Col span={10}>
+            <div style={labelStyle}>Nome</div>
+            {isView ? (
+              <div style={{ ...valueStyle, marginTop: 12 }}>{data?.nome ?? ""}</div>
+            ) : (
+              <Form.Item
+                name="nome"
+                style={{ marginTop: 12, marginBottom: 0 }}
+                rules={[
+                  { required: true, whitespace: true, message: "Campo obrigatório." },
+                ]}
+              >
+                <Input size="large" placeholder="Nome" />
+              </Form.Item>
+            )}
+          </Col>
+          <Col span={8}>
+            <div style={labelStyle}>E-mail</div>
+            {isView ? (
+              <div style={{ ...valueStyle, marginTop: 12 }}>{data?.email ?? ""}</div>
+            ) : (
+              <Form.Item
+                name="email"
+                style={{ marginTop: 12, marginBottom: 0 }}
+                rules={[
+                  { required: true, whitespace: true, message: "Campo obrigatório." },
+                  { type: "email", message: "Informe um e-mail válido." },
+                ]}
+              >
+                <Input size="large" placeholder="E-mail" />
+              </Form.Item>
+            )}
+          </Col>
 
-        <Col span={12}>
-          <div style={{ ...labelStyle, marginTop: 4 }}>Permissões</div>
-          <Select
-            mode="multiple"
-            allowClear
-            size="large"
-            value={permissoes}
-            onChange={(v) => setPermissoes(v)}
-            disabled={isView}
-            style={{ width: "100%", marginTop: 12 }}
-            placeholder="Selecione"
-            options={
-              permissoesOptions?.length
-                ? permissoesOptions
-                : [
-                    { value: "Administrador", label: "Administrador" },
-                    { value: "Gestor", label: "Gestor" },
-                    { value: "Operador", label: "Operador" },
-                    { value: "Consulta", label: "Consulta" },
-                  ]
-            }
-          />
-        </Col>
-      </Row>
+          <Col span={12}>
+            <div style={{ ...labelStyle, marginTop: 4 }}>Permissões</div>
+            <Select
+              mode="multiple"
+              allowClear
+              size="large"
+              value={permissoes}
+              onChange={(v) => setPermissoes(v)}
+              disabled={isView}
+              style={{ width: "100%", marginTop: 12 }}
+              placeholder="Selecione"
+              options={
+                permissoesOptions?.length
+                  ? permissoesOptions
+                  : [
+                      { value: "Administrador", label: "Administrador" },
+                      { value: "Gestor", label: "Gestor" },
+                      { value: "Operador", label: "Operador" },
+                      { value: "Consulta", label: "Consulta" },
+                    ]
+              }
+            />
+          </Col>
+        </Row>
+      </Form>
 
       <div
         style={{


### PR DESCRIPTION
## Resumo

- Adiciona validação client-side no modal de edição de permissão (`EditarPermissaoModal`) para os campos **Nome** e **E-mail**, antecipando regras que hoje só falham após o request ao backend.
- Refatora o modal para usar **Ant Design `Form` + `Form.Item` com `rules` nativas**, mesmo padrão já usado em `AdicionarAutorizacaoModal`.
- O envio para `onSave` é bloqueado quando há erros de validação (`form.validateFields()`).

## Regras aplicadas

| Campo  | Vazio / só-espaços          | Formato inválido               |
|--------|------------------------------|--------------------------------|
| Nome   | "Campo obrigatório."         | —                              |
| E-mail | "Campo obrigatório."         | "Informe um e-mail válido."    |

Implementado via `rules` declarativas:
- `{ required: true, whitespace: true, message: "Campo obrigatório." }`
- `{ type: "email", message: "Informe um e-mail válido." }` (apenas e-mail)

A validação dispara no `onBlur` (padrão do `Form.Item`) e novamente no clique em "Salvar permissão".


[AB#149043](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149043)
[AB#148945](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148945)