### PR TITLE
feat(149044): validacao de email ja cadastro

### DIFF
--- a/src/pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/PermissaoUsuarioTela.tsx
@@ -16,7 +16,6 @@ import type {
   AtivacaoModalMode,
   AtivacaoModalStep,
   EditarPermissaoModalMode,
-  EditarPermissaoModalSavePayload,
   IPermissaoUsuarioRow,
 } from "../../../services/resources/permissoes/IPermissoes";
 import { getGruposDisponiveisOptions, getUsuariosComGrupos } from "./hooks/getPermissaoUsuario";
@@ -260,41 +259,15 @@ const PermissaoUsuarioTela: React.FC = () => {
             email: selectedUser?.email,
             permissoes: selectedUser?.grupos || (selectedUser?.permissoes ? [selectedUser.permissoes] : []),
           }}
+          username={selectedUser?.username || selectedUser?.login}
           onClose={() => setModalOpen(false)}
           permissoesOptions={gruposOptions}
-          onSave={async (next: EditarPermissaoModalSavePayload | undefined) => {
-            const username = selectedUser?.username || selectedUser?.login;
-            if (!username) {
-              setModalOpen(false);
-              return;
-            }
-
-            const nextPermissoes = next?.permissoes || [];
-            const payload: any = { username, grupos: nextPermissoes };
-
-            const currentNome = (selectedUser?.nome ?? "").trim();
-            const nextNome = (next?.nome ?? "").trim();
-            if (next?.nome !== undefined && nextNome !== currentNome) {
-              payload.nome = nextNome;
-            }
-
-            const currentEmail = (selectedUser?.email ?? "").trim();
-            const nextEmail = (next?.email ?? "").trim();
-            if (next?.email !== undefined && nextEmail !== currentEmail) {
-              payload.email = nextEmail;
-            }
-
-            try {
-              await patchUsuario(payload);
-              setPermissaoSucessoNome(selectedUser?.nome || selectedUser?.login || "");
-              setPermissaoSucessoOpen(true);
-              setModalOpen(false);
-              const vals = (control as any)?._formValues ?? {};
-              void handleSub(vals);
-            } catch (e: any) {
-              console.error("Falha ao salvar permissão do usuário:", e);
-              message.error("Não foi possível salvar a permissão do usuário.");
-            }
+          onSuccess={(savedNome) => {
+            setPermissaoSucessoNome(savedNome || selectedUser?.nome || selectedUser?.login || "");
+            setPermissaoSucessoOpen(true);
+            setModalOpen(false);
+            const vals = (control as any)?._formValues ?? {};
+            void handleSub(vals);
           }}
         />
         <ConteudoPagina>

--- a/src/pages/Gerenciar/PermissaoUsuario/__tests__/PermissaoUsuarioTela.test.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/__tests__/PermissaoUsuarioTela.test.tsx
@@ -80,42 +80,23 @@ jest.mock("../components/EditarPermissaoModal", () => {
   return function EditarPermissaoModal({
     open,
     onClose,
-    onSave,
+    onSuccess,
+    username,
     mode,
   }: any) {
     if (!open) return null;
     return (
       <div data-testid="editar-permissao-modal">
         <div data-testid="modal-mode">{mode}</div>
+        <div data-testid="modal-username">{username ?? ""}</div>
         <button data-testid="modal-close" onClick={onClose}>
           Fechar
         </button>
         <button
-          data-testid="modal-save"
-          onClick={() =>
-            onSave?.({
-              permissoes: ["grupo1"],
-              nome: "Nome Atualizado",
-              email: "email@teste.com",
-            })
-          }
+          data-testid="modal-success"
+          onClick={() => onSuccess?.("Nome Atualizado")}
         >
-          Salvar
-        </button>
-        <button
-          data-testid="modal-save-empty"
-          onClick={() => onSave?.(undefined)}
-        >
-          Salvar vazio
-        </button>
-        <button
-          data-testid="modal-save-no-username"
-          onClick={() => {
-            // Simula caso sem username
-            onSave?.({ permissoes: [] });
-          }}
-        >
-          Salvar sem username
+          Sucesso
         </button>
       </div>
     );
@@ -579,7 +560,7 @@ describe("PermissaoUsuarioTela", () => {
       });
     });
 
-    it("deve salvar permissões ao clicar em Salvar", async () => {
+    it("deve abrir SucessoModal quando onSuccess é disparado", async () => {
       const user = userEvent.setup();
       const wrapper = createWrapper();
       render(<PermissaoUsuarioTela />, { wrapper });
@@ -599,48 +580,15 @@ describe("PermissaoUsuarioTela", () => {
         expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
       });
 
-      const saveButton = screen.getByTestId("modal-save");
-      await user.click(saveButton);
+      const successButton = screen.getByTestId("modal-success");
+      await user.click(successButton);
 
       await waitFor(() => {
-        expect(mockPatchUsuario).toHaveBeenCalled();
         expect(screen.getByTestId("sucesso-modal")).toBeInTheDocument();
       });
     });
 
-    it("deve tratar erro ao salvar permissões", async () => {
-      const user = userEvent.setup();
-      mockPatchUsuario.mockRejectedValueOnce(new Error("Erro ao salvar"));
-
-      const wrapper = createWrapper();
-      render(<PermissaoUsuarioTela />, { wrapper });
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("table-loading")).not.toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("row-edit-0")).toBeInTheDocument();
-      });
-
-      const editButton = screen.getByTestId("row-edit-0");
-      await user.click(editButton);
-
-      await waitFor(() => {
-        expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
-      });
-
-      const saveButton = screen.getByTestId("modal-save");
-      await user.click(saveButton);
-
-      await waitFor(() => {
-        expect(message.error).toHaveBeenCalledWith(
-          "Não foi possível salvar a permissão do usuário."
-        );
-      });
-    });
-
-    it("deve atualizar nome quando diferente", async () => {
+    it("deve passar username do usuário selecionado ao modal", async () => {
       const user = userEvent.setup();
       const wrapper = createWrapper();
       render(<PermissaoUsuarioTela />, { wrapper });
@@ -657,96 +605,8 @@ describe("PermissaoUsuarioTela", () => {
       await user.click(editButton);
 
       await waitFor(() => {
-        expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
+        expect(screen.getByTestId("modal-username")).toHaveTextContent("user1");
       });
-
-      const saveButton = screen.getByTestId("modal-save");
-      await user.click(saveButton);
-
-      await waitFor(() => {
-        expect(mockPatchUsuario).toHaveBeenCalledWith(
-          expect.objectContaining({
-            username: "user1",
-            nome: "Nome Atualizado",
-          })
-        );
-      });
-    });
-
-    it("deve atualizar email quando diferente", async () => {
-      const user = userEvent.setup();
-      const wrapper = createWrapper();
-      render(<PermissaoUsuarioTela />, { wrapper });
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("table-loading")).not.toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("row-edit-0")).toBeInTheDocument();
-      });
-
-      const editButton = screen.getByTestId("row-edit-0");
-      await user.click(editButton);
-
-      await waitFor(() => {
-        expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
-      });
-
-      const saveButton = screen.getByTestId("modal-save");
-      await user.click(saveButton);
-
-      await waitFor(() => {
-        expect(mockPatchUsuario).toHaveBeenCalledWith(
-          expect.objectContaining({
-            username: "user1",
-            email: "email@teste.com",
-          })
-        );
-      });
-    });
-
-    it("deve tratar caso sem username ao salvar", async () => {
-      const user = userEvent.setup();
-      mockGetUsuariosComGrupos.mockResolvedValueOnce({
-        results: [
-          {
-            usuario: undefined,
-            nome: "Sem Username",
-            grupos: [],
-            is_active: true,
-          },
-        ],
-      });
-
-      const wrapper = createWrapper();
-      render(<PermissaoUsuarioTela />, { wrapper });
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("table-loading")).not.toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("row-edit-0")).toBeInTheDocument();
-      });
-
-      const editButton = screen.getByTestId("row-edit-0");
-      await user.click(editButton);
-
-      await waitFor(() => {
-        expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
-      });
-
-      const saveButton = screen.getByTestId("modal-save-no-username");
-      if (saveButton) {
-        await user.click(saveButton);
-
-        await waitFor(() => {
-          expect(
-            screen.queryByTestId("editar-permissao-modal")
-          ).not.toBeInTheDocument();
-        });
-      }
     });
 
     it("deve usar permissoes quando grupos não existir", async () => {
@@ -1032,8 +892,8 @@ describe("PermissaoUsuarioTela", () => {
         expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
       });
 
-      const saveButton = screen.getByTestId("modal-save");
-      await user.click(saveButton);
+      const successButton = screen.getByTestId("modal-success");
+      await user.click(successButton);
 
       await waitFor(() => {
         expect(screen.getByTestId("sucesso-modal")).toBeInTheDocument();
@@ -1192,74 +1052,5 @@ describe("PermissaoUsuarioTela", () => {
     });
   });
 
-  describe("Validação de nome e email no save", () => {
-    it("não deve atualizar nome quando igual", async () => {
-      const user = userEvent.setup();
-      const wrapper = createWrapper();
-      render(<PermissaoUsuarioTela />, { wrapper });
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("table-loading")).not.toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("row-edit-0")).toBeInTheDocument();
-      });
-
-      const editButton = screen.getByTestId("row-edit-0");
-      await user.click(editButton);
-
-      await waitFor(() => {
-        expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
-      });
-
-      // Simula salvar com mesmo nome
-      const saveButton = screen.getByTestId("modal-save-empty");
-      if (saveButton) {
-        await user.click(saveButton);
-
-        await waitFor(() => {
-          if (mockPatchUsuario.mock.calls.length > 0) {
-            const call = mockPatchUsuario.mock.calls[0][0];
-            expect(call).not.toHaveProperty("nome");
-          }
-        });
-      }
-    });
-
-    it("não deve atualizar email quando igual", async () => {
-      const user = userEvent.setup();
-      const wrapper = createWrapper();
-      render(<PermissaoUsuarioTela />, { wrapper });
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("table-loading")).not.toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("row-edit-0")).toBeInTheDocument();
-      });
-
-      const editButton = screen.getByTestId("row-edit-0");
-      await user.click(editButton);
-
-      await waitFor(() => {
-        expect(screen.getByTestId("editar-permissao-modal")).toBeInTheDocument();
-      });
-
-      // Simula salvar com mesmo email
-      const saveButton = screen.getByTestId("modal-save-empty");
-      if (saveButton) {
-        await user.click(saveButton);
-
-        await waitFor(() => {
-          if (mockPatchUsuario.mock.calls.length > 0) {
-            const call = mockPatchUsuario.mock.calls[0][0];
-            expect(call).not.toHaveProperty("email");
-          }
-        });
-      }
-    });
-  });
 });
 

--- a/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
+++ b/src/pages/Gerenciar/PermissaoUsuario/components/EditarPermissaoModal.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Button, Col, Form, Input, Modal, Row, Select, Typography } from "antd";
+import { Button, Col, Form, Input, Modal, Row, Select, Typography, message } from "antd";
 
 import { ClearButton } from "../../../Processos/ConvocacaoCandidatos/style";
 import type { EditarPermissaoModalProps } from "../../../../services/resources/permissoes/IPermissoes";
+import { patchUsuario } from "../hooks/patchAtualizarPermissoesUsuarios";
 
 const labelStyle: React.CSSProperties = {
   fontFamily: "Open Sans",
@@ -22,12 +23,14 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
   open,
   mode,
   data,
+  username,
   permissoesOptions,
   onClose,
-  onSave,
+  onSuccess,
 }) => {
   const [form] = Form.useForm<{ nome: string; email: string }>();
   const [permissoes, setPermissoes] = React.useState<string[]>(data?.permissoes ?? []);
+  const [saving, setSaving] = React.useState(false);
 
   React.useEffect(() => {
     if (open) {
@@ -43,6 +46,52 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
 
   const isView = mode === "view";
 
+  const handleSalvar = async () => {
+    if (!username) {
+      onClose();
+      return;
+    }
+
+    let values: { nome: string; email: string };
+    try {
+      values = await form.validateFields();
+    } catch {
+      return;
+    }
+
+    const currentNome = (data?.nome ?? "").trim();
+    const nextNome = (values.nome ?? "").trim();
+    const currentEmail = (data?.email ?? "").trim();
+    const nextEmail = (values.email ?? "").trim();
+
+    const payload: {
+      username: string;
+      grupos: string[];
+      nome?: string;
+      email?: string;
+    } = { username, grupos: permissoes };
+
+    if (nextNome !== currentNome) payload.nome = nextNome;
+    if (nextEmail !== currentEmail) payload.email = nextEmail;
+
+    setSaving(true);
+    try {
+      await patchUsuario(payload);
+      onSuccess?.(nextNome || data?.nome || "");
+    } catch (e: any) {
+      const respData = e?.response?.data;
+      const emailErr = Array.isArray(respData?.email) ? respData.email[0] : undefined;
+      if (emailErr) {
+        form.setFields([{ name: "email", errors: [String(emailErr)] }]);
+        return;
+      }
+      console.error("Falha ao salvar permissão do usuário:", e);
+      message.error("Não foi possível salvar a permissão do usuário.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <Modal
       open={open}
@@ -54,6 +103,7 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
             size="large"
             style={{ height: 48, width: 152, marginTop: 0 }}
             onClick={onClose}
+            disabled={saving}
           >
             Cancelar
           </ClearButton>
@@ -62,18 +112,8 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
               size="large"
               type="primary"
               style={{ height: 48, width: 200, marginTop: 0 }}
-              onClick={async () => {
-                try {
-                  const values = await form.validateFields();
-                  onSave?.({
-                    permissoes,
-                    nome: values.nome,
-                    email: values.email,
-                  });
-                } catch {
-                  // validateFields lança quando há erros; o Form já exibe as mensagens
-                }
-              }}
+              loading={saving}
+              onClick={handleSalvar}
             >
               Salvar permissão
             </Button>
@@ -104,6 +144,12 @@ const EditarPermissaoModal: React.FC<EditarPermissaoModalProps> = ({
                 style={{ marginTop: 12, marginBottom: 0 }}
                 rules={[
                   { required: true, whitespace: true, message: "Campo obrigatório." },
+                  { min: 3, message: "O nome deve ter ao menos 3 caracteres." },
+                  { max: 100, message: "O nome deve ter no máximo 100 caracteres." },
+                  {
+                    pattern: /^[A-Za-zÀ-ÿ\s'-]+$/,
+                    message: "O nome não pode conter números ou caracteres especiais.",
+                  },
                 ]}
               >
                 <Input size="large" placeholder="Nome" />

--- a/src/services/resources/permissoes/IPermissoes.ts
+++ b/src/services/resources/permissoes/IPermissoes.ts
@@ -47,19 +47,14 @@ export interface EditarPermissaoModalData {
   permissoes?: string[];
 }
 
-export interface EditarPermissaoModalSavePayload {
-  permissoes?: string[];
-  nome?: string;
-  email?: string;
-}
-
 export interface EditarPermissaoModalProps {
   open: boolean;
   mode: EditarPermissaoModalMode;
   data?: EditarPermissaoModalData;
+  username?: string;
   permissoesOptions?: Array<{ value: string; label: string }>;
   onClose: () => void;
-  onSave?: (next?: EditarPermissaoModalSavePayload) => void | Promise<void>;
+  onSuccess?: (savedNome: string) => void;
 }
 
 export interface IPermissaoUsuarioRow {


### PR DESCRIPTION
## Resumo

- Erros 400 do backend ao salvar permissão (ex.: e-mail já em uso) agora aparecem
  em vermelho abaixo do input de e-mail, ao invés de um toast genérico.
- Campo "Nome" do modal Editar Permissão passou a validar: obrigatório, mínimo 3
  e máximo 100 caracteres, e rejeita números/caracteres especiais
  (aceita letras com acentos, espaços, hífen e apóstrofo).
- Chamada de `patchUsuario` foi movida de `PermissaoUsuarioTela` para dentro do
  próprio `EditarPermissaoModal`, permitindo capturar o erro do servidor e
  mapeá-lo para o campo via `form.setFields`. Tipos atualizados:
  `EditarPermissaoModalProps` agora recebe `username` e `onSuccess` no lugar de
  `onSave`.

[AB#149044](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149044)
[AB#148945](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148945)