### PR TITLE
feat(150057): ajuste para passar concurso_uuid para o back de importa vagas

### DIFF
--- a/src/pages/ImportacaoDados/Vagas/hooks/__tests__/index.test.tsx
+++ b/src/pages/ImportacaoDados/Vagas/hooks/__tests__/index.test.tsx
@@ -368,6 +368,7 @@ describe('ImportacaoDados Hooks - Cobertura Completa', () => {
       expect(API.ImportacaoDados.postImportacaoArquivosVagas).toHaveBeenCalledWith({
         processo_nome: undefined,
         processo_uuid: 'PROCESSO_001',
+        concurso_uuid: undefined,
         arquivo: testFile,
       });
     });

--- a/src/pages/ImportacaoDados/Vagas/hooks/types.ts
+++ b/src/pages/ImportacaoDados/Vagas/hooks/types.ts
@@ -26,5 +26,6 @@ export interface IImportacaoVagasForm {
 export interface IImportacaoVagasPayload {
   processo_nome?:string;
   processo_uuid?:string;
+  concurso_uuid?:string;
   arquivo: File;
 }

--- a/src/pages/ImportacaoDados/Vagas/hooks/useImportacaoDadosVagas.tsx
+++ b/src/pages/ImportacaoDados/Vagas/hooks/useImportacaoDadosVagas.tsx
@@ -59,6 +59,7 @@ export const useImportacaoDadosVagas = () => {
     return processosConvocacaoData.results.map((processo: any) => ({
       value: processo.uuid,
       label: processo.descricao,
+      concurso_uuid: processo.concurso_uuid,
     }));
   }, [processosConvocacaoData]);
 
@@ -71,11 +72,13 @@ export const useImportacaoDadosVagas = () => {
 
   const handleEnviarForm = async (data: IImportacaoVagasForm) => {
     const uuid = data.processo_convocacao!;
-    const label = (processosConvocacaoOptions || []).find((o: any) => o?.value === uuid)?.label as string | undefined;
+    const selected = (processosConvocacaoOptions || []).find((o: any) => o?.value === uuid);
+    const label = selected?.label as string | undefined;
 
     const payload: IImportacaoVagasPayload = {
       processo_nome: label,
       processo_uuid: uuid,
+      concurso_uuid: selected?.concurso_uuid as string | undefined,
       arquivo: data.arquivo!,
     };
     try {


### PR DESCRIPTION
Passa concurso_uuid para o back em importa_vagas

[AB#148916](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148916)
[AB#150057](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/150057)