### PR TITLE
feat(150060): Implementação do download de pdf em extracao dados

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sme-cogep-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@ant-design/charts": "^2.6.7",
         "@babel/preset-typescript": "^7.27.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -18,6 +19,8 @@
         "@tanstack/react-query": "^5.76.1",
         "antd": "^5.25.2",
         "axios": "^1.10.0",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.2.1",
         "lodash": "^4.17.21",
         "quill": "^1.3.7",
         "react": "^19.1.0",
@@ -76,6 +79,34 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@ant-design/charts": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@ant-design/charts/-/charts-2.6.7.tgz",
+      "integrity": "sha512-XfmsnspUpfrMlRFGTwmHJ2TPKcosq5a5nSxAfIOpEXAvmJBT2N16oejGTZhUFTzba8W3XtBOziwRAXmDmLUqvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/graphs": "^2.1.1",
+        "@ant-design/plots": "^2.6.7",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
+      }
+    },
+    "node_modules/@ant-design/charts-util": {
+      "version": "0.0.1-alpha.7",
+      "resolved": "https://registry.npmjs.org/@ant-design/charts-util/-/charts-util-0.0.1-alpha.7.tgz",
+      "integrity": "sha512-Yh0o6EdO6SvdSnStFZMbnUzjyymkVzV+TQ9ymVW9hlVgO/fUkUII3JYSdV+UVcFnYwUF0YiDKuSTLCZNAzg2bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
+      }
+    },
     "node_modules/@ant-design/colors": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
@@ -131,6 +162,24 @@
         "node": ">=8.x"
       }
     },
+    "node_modules/@ant-design/graphs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/graphs/-/graphs-2.1.1.tgz",
+      "integrity": "sha512-qT3Oo8BWeoAmZEy9gfR6uIk+rczbNJ3sWXKonoOD5koATWv7dY0kgvS1JnhdM1QW4FkfPPJTeQVSlRRUtvWDwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/charts-util": "0.0.1-alpha.7",
+        "@antv/g6": "^5.0.44",
+        "@antv/g6-extension-react": "^0.2.0",
+        "@antv/graphin": "^3.0.4",
+        "lodash": "^4.17.21",
+        "styled-components": "^6.1.15"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
+      }
+    },
     "node_modules/@ant-design/icons": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
@@ -157,6 +206,37 @@
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
       "license": "MIT"
     },
+    "node_modules/@ant-design/plots": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/@ant-design/plots/-/plots-2.6.8.tgz",
+      "integrity": "sha512-QsunUs2d5rbq/1BwVhga/siA5H50OaG23YopMYwPD4sPsza6NQzPQ8FM3elNIsD/BIk298tihqX1cJ/MmvVJbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/charts-util": "0.0.3",
+        "@antv/event-emitter": "^0.1.3",
+        "@antv/g": "^6.1.7",
+        "@antv/g2": "^5.2.7",
+        "@antv/g2-extension-plot": "^0.2.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
+      }
+    },
+    "node_modules/@ant-design/plots/node_modules/@ant-design/charts-util": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/charts-util/-/charts-util-0.0.3.tgz",
+      "integrity": "sha512-x1H7UT6t4dXAyGRoHqlOnEsEqBSTANFGTZEAMI0CWYhYUpp13n0o9grl9oPtoL6FEQMjUBTY+zGJKlHkz8smMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
+      }
+    },
     "node_modules/@ant-design/react-slick": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
@@ -171,6 +251,372 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@antv/algorithm": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@antv/algorithm/-/algorithm-0.1.26.tgz",
+      "integrity": "sha512-DVhcFSQ8YQnMNW34Mk8BSsfc61iC1sAnmcfYoXTAshYHuU50p/6b7x3QYaGctDNKWGvi1ub7mPcSY0bK+aN0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^2.0.13",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@antv/algorithm/node_modules/@antv/util": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-2.0.17.tgz",
+      "integrity": "sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==",
+      "license": "ISC",
+      "dependencies": {
+        "csstype": "^3.0.8",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@antv/component": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@antv/component/-/component-2.1.11.tgz",
+      "integrity": "sha512-dTdz8VAd3rpjOaGEZTluz82mtzrP4XCtNlNQyrxY7VNRNcjtvpTLDn57bUL2lRu1T+iklKvgbE2llMriWkq9vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g": "^6.1.11",
+        "@antv/scale": "^0.4.16",
+        "@antv/util": "^3.3.10",
+        "svg-path-parser": "^1.1.0"
+      }
+    },
+    "node_modules/@antv/component/node_modules/@antv/scale": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.4.16.tgz",
+      "integrity": "sha512-5wg/zB5kXHxpTV5OYwJD3ja6R8yTiqIOkjOhmpEJiowkzRlbEC/BOyMvNUq5fqFIHnMCE9woO7+c3zxEQCKPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.7",
+        "color-string": "^1.5.5",
+        "fecha": "^4.2.1"
+      }
+    },
+    "node_modules/@antv/coord": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@antv/coord/-/coord-0.4.7.tgz",
+      "integrity": "sha512-UTbrMLhwJUkKzqJx5KFnSRpU3BqrdLORJbwUbHK2zHSCT3q3bjcFA//ZYLVfIlwqFDXp/hzfMyRtp0c77A9ZVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/scale": "^0.4.12",
+        "@antv/util": "^2.0.13",
+        "gl-matrix": "^3.4.3"
+      }
+    },
+    "node_modules/@antv/coord/node_modules/@antv/scale": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.4.16.tgz",
+      "integrity": "sha512-5wg/zB5kXHxpTV5OYwJD3ja6R8yTiqIOkjOhmpEJiowkzRlbEC/BOyMvNUq5fqFIHnMCE9woO7+c3zxEQCKPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.7",
+        "color-string": "^1.5.5",
+        "fecha": "^4.2.1"
+      }
+    },
+    "node_modules/@antv/coord/node_modules/@antv/scale/node_modules/@antv/util": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-3.3.11.tgz",
+      "integrity": "sha512-FII08DFM4ABh2q5rPYdr0hMtKXRgeZazvXaFYCs7J7uTcWDHUhczab2qOCJLNDugoj8jFag1djb7wS9ehaRYBg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "gl-matrix": "^3.3.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@antv/coord/node_modules/@antv/util": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-2.0.17.tgz",
+      "integrity": "sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==",
+      "license": "ISC",
+      "dependencies": {
+        "csstype": "^3.0.8",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@antv/event-emitter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@antv/event-emitter/-/event-emitter-0.1.3.tgz",
+      "integrity": "sha512-4ddpsiHN9Pd4UIlWuKVK1C4IiZIdbwQvy9i7DUSI3xNJ89FPUFt8lxDYj8GzzfdllV0NkJTRxnG+FvLk0llidg==",
+      "license": "MIT"
+    },
+    "node_modules/@antv/expr": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@antv/expr/-/expr-1.0.2.tgz",
+      "integrity": "sha512-vrfdmPHkTuiS5voVutKl2l06w1ihBh9A8SFdQPEE+2KMVpkymzGOF1eWpfkbGZ7tiFE15GodVdhhHomD/hdIwg==",
+      "license": "MIT"
+    },
+    "node_modules/@antv/g": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@antv/g/-/g-6.3.1.tgz",
+      "integrity": "sha512-WYEKqy86LHB2PzTmrZXrIsIe+3Epeds2f68zceQ+BJtRoGki7Sy4IhlC8LrUMztgfT1t3d/0L745NWZwITroKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.7.0",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "html2canvas": "^1.4.1"
+      }
+    },
+    "node_modules/@antv/g-canvas": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@antv/g-canvas/-/g-canvas-2.2.0.tgz",
+      "integrity": "sha512-h7zVBBo2aO64DuGKvq9sG+yTU3sCUb9DALCVm7nz8qGPs8hhLuFOkKPEzUDNfNYZGJUGzY8UDtJ3QRGRFcvEQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.7.0",
+        "@antv/g-math": "3.1.0",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-lite": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@antv/g-lite/-/g-lite-2.7.0.tgz",
+      "integrity": "sha512-uSzgHYa5bwR5L2Au7/5tsOhFmXKZKLPBH90+Q9bP9teVs5VT4kOAi0isPSpDI8uhdDC2/VrfTWu5K9HhWI6FWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-math": "3.1.0",
+        "@antv/util": "^3.3.5",
+        "@antv/vendor": "^1.0.3",
+        "@babel/runtime": "^7.25.6",
+        "eventemitter3": "^5.0.1",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-lite/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@antv/g-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@antv/g-math/-/g-math-3.1.0.tgz",
+      "integrity": "sha512-DtN1Gj/yI0UiK18nSBsZX8RK0LszGwqfb+cBYWgE+ddyTm8dZnW4tPUhV7QXePsS6/A5hHC+JFpAAK7OEGo5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-dragndrop": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-dragndrop/-/g-plugin-dragndrop-2.1.1.tgz",
+      "integrity": "sha512-+aesDUJVQDs6UJ2bOBbDlaGAPCfHmU0MbrMTlQlfpwNplWueqtgVAZ3L57oZ2ZGHRWUHiRwZGPjXMBM3O2LELw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.7.0",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-svg": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@antv/g-svg/-/g-svg-2.1.1.tgz",
+      "integrity": "sha512-gVzBkjqA8FzDTbkuIxj6L0Omz/X/hFbYLzK6alWr0sHTfywqP6czcjDUJU8DF2MRIY1Twy55uZYW4dqqLXOXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.7.0",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g2": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-5.4.8.tgz",
+      "integrity": "sha512-IvgIpwmT4M5/QAd3Mn2WiHIDeBqFJ4WA2gcZhRRSZuZ2KmgCqZWZwwIT0hc+kIGxwYeDoCQqf//t6FMVu3ryBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/component": "^2.1.9",
+        "@antv/coord": "^0.4.7",
+        "@antv/event-emitter": "^0.1.3",
+        "@antv/expr": "^1.0.2",
+        "@antv/g": "^6.1.24",
+        "@antv/g-canvas": "^2.0.43",
+        "@antv/g-plugin-dragndrop": "^2.0.35",
+        "@antv/scale": "^0.5.1",
+        "@antv/util": "^3.3.10",
+        "@antv/vendor": "^1.0.11",
+        "flru": "^1.0.2",
+        "pdfast": "^0.2.0"
+      }
+    },
+    "node_modules/@antv/g2-extension-plot": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@antv/g2-extension-plot/-/g2-extension-plot-0.2.2.tgz",
+      "integrity": "sha512-KJXCXO7as+h0hDqirGXf1omrNuYzQmY3VmBmp7lIvkepbQ7sz3pPwy895r1FWETGF3vTk5UeFcAF5yzzBHWgbw==",
+      "dependencies": {
+        "@antv/g2": "^5.1.8",
+        "@antv/util": "^3.3.5",
+        "@antv/vendor": "^1.0.10"
+      }
+    },
+    "node_modules/@antv/g6": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@antv/g6/-/g6-5.1.1.tgz",
+      "integrity": "sha512-50bXxMUf4mChyOv4ePVeWZLwotih9VunKfp0a++Wofv/wCyY8fb9+CV2wouIBCOZnd5ydBRA4NNaX9yLJzqa2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/algorithm": "^0.1.26",
+        "@antv/component": "^2.1.7",
+        "@antv/event-emitter": "^0.1.3",
+        "@antv/g": "^6.1.28",
+        "@antv/g-canvas": "^2.0.48",
+        "@antv/g-plugin-dragndrop": "^2.0.38",
+        "@antv/graphlib": "^2.0.4",
+        "@antv/hierarchy": "^0.7.1",
+        "@antv/layout": "^2.0.0",
+        "@antv/util": "^3.3.11",
+        "bubblesets-js": "^2.3.4"
+      }
+    },
+    "node_modules/@antv/g6-extension-react": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@antv/g6-extension-react/-/g6-extension-react-0.2.7.tgz",
+      "integrity": "sha512-X/zxGiL/kyJ+5xteX1+P2mI07oLw+zfvKcIHxfynL7IGCQCwQ6q91LkJaOlSDTuWhNRXwnwJ4Cf2Nt/9Dhq5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g": "^6.1.24",
+        "@antv/g-svg": "^2.0.38"
+      },
+      "peerDependencies": {
+        "@antv/g6": "^5.1.0",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@antv/graphin": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@antv/graphin/-/graphin-3.0.5.tgz",
+      "integrity": "sha512-V/j8R8Ty44wUqxVIYLdpPuIO8WWCTIVq1eBJg5YRunL5t5o5qAFpC/qkQxslbBMWyKdIH0oWBnvHA74riGi7cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g6": "^5.0.28"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.1.0",
+        "react-dom": "^18.0.0 || ^19.1.0"
+      }
+    },
+    "node_modules/@antv/graphlib": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@antv/graphlib/-/graphlib-2.0.4.tgz",
+      "integrity": "sha512-zc/5oQlsdk42Z0ib1mGklwzhJ5vczLFiPa1v7DgJkTbgJ2YxRh9xdarf86zI49sKVJmgbweRpJs7Nu5bIiwv4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/event-emitter": "^0.1.3"
+      }
+    },
+    "node_modules/@antv/hierarchy": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@antv/hierarchy/-/hierarchy-0.7.1.tgz",
+      "integrity": "sha512-7r22r+HxfcRZp79ZjGmsn97zgC1Iajrv0Mm9DIgx3lPfk+Kme2MG/+EKdZj1iEBsN0rJRzjWVPGL5YrBdVHchw==",
+      "license": "MIT"
+    },
+    "node_modules/@antv/layout": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@antv/layout/-/layout-2.0.0.tgz",
+      "integrity": "sha512-aCZ3UdNc40SfT7meFV7QTADY2HCnc0DShVw56CJNTI6oExUIVU736grPuL5Dhb8/JrVaU4Y83QPN/P7KafBzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/event-emitter": "^0.1.3",
+        "@antv/expr": "^1.0.2",
+        "@antv/graphlib": "^2.0.0",
+        "@antv/util": "^3.3.2",
+        "comlink": "^4.4.1",
+        "d3-force": "^3.0.0",
+        "d3-force-3d": "^3.0.5",
+        "d3-octree": "^1.0.2",
+        "d3-quadtree": "^3.0.1",
+        "dagre": "^0.8.5",
+        "ml-matrix": "^6.10.4",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@antv/scale": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.5.2.tgz",
+      "integrity": "sha512-rTHRAwvpHWC5PGZF/mJ2ZuTDqwwvVBDRph0Uu5PV9BXwzV7K8+9lsqGJ+XHVLxe8c6bKog5nlzvV/dcYb0d5Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.7",
+        "color-string": "^1.5.5",
+        "fecha": "^4.2.1"
+      }
+    },
+    "node_modules/@antv/util": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-3.3.11.tgz",
+      "integrity": "sha512-FII08DFM4ABh2q5rPYdr0hMtKXRgeZazvXaFYCs7J7uTcWDHUhczab2qOCJLNDugoj8jFag1djb7wS9ehaRYBg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "gl-matrix": "^3.3.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@antv/vendor": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@antv/vendor/-/vendor-1.0.11.tgz",
+      "integrity": "sha512-LmhPEQ+aapk3barntaiIxJ5VHno/Tyab2JnfdcPzp5xONh/8VSfed4bo/9xKo5HcUAEydko38vYLfj6lJliLiw==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.2.1",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-dispatch": "^3.0.6",
+        "@types/d3-dsv": "^3.0.7",
+        "@types/d3-ease": "^3.0.2",
+        "@types/d3-fetch": "^3.0.7",
+        "@types/d3-force": "^3.0.10",
+        "@types/d3-format": "^3.0.4",
+        "@types/d3-geo": "^3.1.0",
+        "@types/d3-hierarchy": "^3.1.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-path": "^3.1.0",
+        "@types/d3-quadtree": "^3.0.6",
+        "@types/d3-random": "^3.0.3",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-scale-chromatic": "^3.1.0",
+        "@types/d3-shape": "^3.1.7",
+        "@types/d3-time": "^3.0.4",
+        "@types/d3-timer": "^3.0.2",
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-dispatch": "^3.0.1",
+        "d3-dsv": "^3.0.1",
+        "d3-ease": "^3.0.1",
+        "d3-fetch": "^3.0.1",
+        "d3-force": "^3.0.0",
+        "d3-force-3d": "^3.0.5",
+        "d3-format": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "d3-geo-projection": "^4.0.0",
+        "d3-hierarchy": "^3.1.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
+        "d3-quadtree": "^3.0.1",
+        "d3-random": "^3.0.1",
+        "d3-regression": "^1.3.10",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2005,9 +2451,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5459,11 +5905,146 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -5579,6 +6160,12 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5590,6 +6177,13 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -5636,6 +6230,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -6355,6 +6956,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -6418,6 +7028,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/bubblesets-js": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/bubblesets-js/-/bubblesets-js-2.3.4.tgz",
+      "integrity": "sha512-DyMjHmpkS2+xcFNtyN00apJYL3ESdp9fTrkDr5+9Qg/GPqFmcWgGsK1akZnttE1XFxJ/VMy4DNNGMGYtmFp1Sg==",
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -6518,6 +7134,26 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6693,8 +7329,17 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6706,6 +7351,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/compute-scroll-into-view": {
@@ -6741,6 +7401,18 @@
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {
@@ -6807,6 +7479,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -6843,6 +7524,304 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-regression": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
+      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -7017,6 +7996,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-case": {
@@ -7580,8 +8569,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.1.2",
@@ -7600,6 +8588,17 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -7624,6 +8623,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -7690,6 +8701,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
+    },
+    "node_modules/flru": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flru/-/flru-1.0.2.tgz",
+      "integrity": "sha512-kWyh8ADvHBFz6ua5xYOPnUroZTT/bwWfrCeL0Wj1dzG4/YOmOcfJ99W8dOVyyynJN35rZ9aCOtHChqQovV7yog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -7861,6 +8881,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -7950,6 +8976,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
@@ -8053,6 +9088,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -8095,7 +9143,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8208,6 +9255,27 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
+    "node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==",
+      "license": "MIT"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -10672,6 +11740,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10936,6 +12021,45 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/ml-array-max": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-2.0.0.tgz",
+      "integrity": "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-2.0.0.tgz",
+      "integrity": "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-2.0.0.tgz",
+      "integrity": "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-max": "^2.0.0",
+        "ml-array-min": "^2.0.0"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.2.tgz",
+      "integrity": "sha512-GC+BnW+pBh8Auap8goAxY0senAmF0IEoc3HNVSfnfbvGw0buuDIYb9kAKMS1l+GiwJ1rfK2bzJ8IHhwjzATSFA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-rescale": "^2.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11157,6 +12281,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parchment": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
@@ -11271,6 +12401,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pdfast": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pdfast/-/pdfast-0.2.0.tgz",
+      "integrity": "sha512-cq6TTu6qKSFUHwEahi68k/kqN2mfepjkGrG9Un70cgdRRKLKY6Rf8P8uvP2NvZktaQZNF3YE7agEkLj0vGK9bA==",
+      "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -11538,6 +12681,16 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/rc-cascader": {
@@ -12351,6 +13504,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -12495,6 +13655,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.44.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
@@ -12541,11 +13711,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -12661,6 +13836,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12739,6 +13929,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/start": {
@@ -13037,6 +14237,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/svg-path-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/svg-path-parser/-/svg-path-parser-1.1.0.tgz",
+      "integrity": "sha512-jGCUqcQyXpfe38R7RFfhrMyfXcBmpMNJI/B+4CE9/Unkh98UporAc461GTthv+TVDuZXsBx7/WiwJb1Oh4tt4A==",
+      "license": "MIT"
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13095,6 +14311,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/throttle-debounce": {
@@ -13210,7 +14435,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -13393,6 +14617,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@tanstack/react-query": "^5.76.1",
     "antd": "^5.25.2",
     "axios": "^1.10.0",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "lodash": "^4.17.21",
     "quill": "^1.3.7",
     "react": "^19.1.0",

--- a/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
@@ -405,7 +405,7 @@ const ExtracaoDadosTela: React.FC = () => {
             <Row gutter={[16, 16]} style={{ marginTop: "1.5rem" }}>
               {isComparativo && indicadoresComparativo ? (
                 <>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<TaskAltIcon fontSize="small" />}
                       title="Habilitados"
@@ -417,7 +417,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Total de pessoas aprovadas e consideradas aptas no concurso"
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<CampaignIcon fontSize="small" />}
                       title="Convocados"
@@ -427,7 +427,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Total de candidatos chamados oficialmente."
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<PersonOffIcon fontSize="small" />}
                       title="Não convocados"
@@ -437,7 +437,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Habilitados que ainda não foram convocados."
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<VerifiedUserIcon fontSize="small" />}
                       title="Autorizações"
@@ -447,7 +447,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Autorizações liberadas para continuidade das contratações."
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<HowToRegIcon fontSize="small" />}
                       title="Escolhas realizadas"
@@ -457,7 +457,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Candidatos que realizaram escolha de vaga ou unidade."
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<ScheduleIcon fontSize="small" />}
                       title="Não escolha"
@@ -467,7 +467,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Convocados que decidiram pela não escolha."
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<ReplayIcon fontSize="small" />}
                       title="Reconvocações"
@@ -477,7 +477,7 @@ const ExtracaoDadosTela: React.FC = () => {
                       description="Candidatos que solicitaram participação em nova chamada."
                     />
                   </Col>
-                  <Col xs={24} sm={12} lg={6}>
+                  <Col xs={24} sm={12} lg={8}>
                     <IndicadorCardComparativo
                       icon={<PendingActionsIcon fontSize="small" />}
                       title="Pendentes de escolha"

--- a/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
@@ -3,12 +3,12 @@ import { Button, Col, Row, Select, Spin, Typography } from "antd";
 import { BarChartOutlined } from "@ant-design/icons";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
-import GroupsIcon from "@mui/icons-material/Groups";
 import CampaignIcon from "@mui/icons-material/Campaign";
 import HowToRegIcon from "@mui/icons-material/HowToReg";
 import PersonOffIcon from "@mui/icons-material/PersonOff";
 import ReplayIcon from "@mui/icons-material/Replay";
 import ScheduleIcon from "@mui/icons-material/Schedule";
+import PendingActionsIcon from "@mui/icons-material/PendingActions";
 import VerifiedUserIcon from "@mui/icons-material/VerifiedUser";
 import BaseTela, { type TitleItem } from "../../Base/BaseTela";
 import { CustomFormItem } from "../../../components/FormStyle";
@@ -49,6 +49,7 @@ import {
 } from "./utils/mapGraficosDre";
 import {
   mapCargosParaAutorizacoesPublicadas,
+  mapConcursoFiltradoParaAutorizacoesPublicadas,
   mapDresConcursosParaRelatoriosDetalhados,
   mapDresParaRelatoriosDetalhados,
 } from "./utils/mapRelatoriosDetalhados";
@@ -233,31 +234,13 @@ const ExtracaoDadosTela: React.FC = () => {
     []
   );
 
-  // Descricao do filtro selecionado na tela, exibida no cabecalho do PDF.
-  // Os dados do PDF permanecem consolidados; isto e apenas informativo.
-  const filtroAplicado = useMemo(() => {
-    const partes: string[] = [];
-
-    if (concursoUuid) {
-      const concursoSelecionado = concursosOptions.find(
-        (concurso: { value: string; label: string }) =>
-          concurso.value === concursoUuid
-      );
-      partes.push(`Concurso: ${concursoSelecionado?.label ?? concursoUuid}`);
-    }
-
-    if (anos.length > 0) {
-      const anosOrdenados = [...anos].sort((a, b) => a.localeCompare(b));
-      partes.push(`Ano: ${anosOrdenados.join(", ")}`);
-    }
-
-    return partes.length > 0 ? partes.join(" | ") : undefined;
-  }, [concursoUuid, anos, concursosOptions]);
-
   const autorizacoesPublicadas = useMemo(
     () =>
       filtrosAplicados
-        ? mapCargosParaAutorizacoesPublicadas(extracaoDados?.concurso?.cargos)
+        ? mapConcursoFiltradoParaAutorizacoesPublicadas(
+            extracaoDados?.concurso,
+            filtrosAplicados.anos
+          )
         : autorizacoesPublicadasTodos,
     [extracaoDados, autorizacoesPublicadasTodos, filtrosAplicados]
   );
@@ -429,19 +412,9 @@ const ExtracaoDadosTela: React.FC = () => {
                       anoAntigo={indicadoresComparativo.anoAntigo}
                       anoRecente={indicadoresComparativo.anoRecente}
                       item={indicadoresComparativo.habilitados}
+                      breakdown={indicadoresComparativo.listaEspecifica.breakdown}
                       modoValorUnico
                       description="Total de pessoas aprovadas e consideradas aptas no concurso"
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <IndicadorCardComparativo
-                      icon={<GroupsIcon fontSize="small" />}
-                      title="Lista específica"
-                      anoAntigo={indicadoresComparativo.anoAntigo}
-                      anoRecente={indicadoresComparativo.anoRecente}
-                      item={indicadoresComparativo.listaEspecifica}
-                      breakdown={indicadoresComparativo.listaEspecifica.breakdown}
-                      description="Distribuição de candidatos por lista de classificação"
                     />
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
@@ -456,16 +429,6 @@ const ExtracaoDadosTela: React.FC = () => {
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <IndicadorCardComparativo
-                      icon={<HowToRegIcon fontSize="small" />}
-                      title="Escolhas realizadas"
-                      anoAntigo={indicadoresComparativo.anoAntigo}
-                      anoRecente={indicadoresComparativo.anoRecente}
-                      item={indicadoresComparativo.escolhasRealizadas}
-                      description="Candidatos que realizaram escolha de vaga ou unidade."
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <IndicadorCardComparativo
                       icon={<PersonOffIcon fontSize="small" />}
                       title="Não convocados"
                       anoAntigo={indicadoresComparativo.anoAntigo}
@@ -476,12 +439,22 @@ const ExtracaoDadosTela: React.FC = () => {
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <IndicadorCardComparativo
-                      icon={<ReplayIcon fontSize="small" />}
-                      title="Reconvocações"
+                      icon={<VerifiedUserIcon fontSize="small" />}
+                      title="Autorizações"
                       anoAntigo={indicadoresComparativo.anoAntigo}
                       anoRecente={indicadoresComparativo.anoRecente}
-                      item={indicadoresComparativo.reconvocacoes}
-                      description="Candidatos que solicitaram participação em nova chamada."
+                      item={indicadoresComparativo.autorizacoes}
+                      description="Autorizações liberadas para continuidade das contratações."
+                    />
+                  </Col>
+                  <Col xs={24} sm={12} lg={6}>
+                    <IndicadorCardComparativo
+                      icon={<HowToRegIcon fontSize="small" />}
+                      title="Escolhas realizadas"
+                      anoAntigo={indicadoresComparativo.anoAntigo}
+                      anoRecente={indicadoresComparativo.anoRecente}
+                      item={indicadoresComparativo.escolhasRealizadas}
+                      description="Candidatos que realizaram escolha de vaga ou unidade."
                     />
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
@@ -496,12 +469,22 @@ const ExtracaoDadosTela: React.FC = () => {
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <IndicadorCardComparativo
-                      icon={<VerifiedUserIcon fontSize="small" />}
-                      title="Autorizações"
+                      icon={<ReplayIcon fontSize="small" />}
+                      title="Reconvocações"
                       anoAntigo={indicadoresComparativo.anoAntigo}
                       anoRecente={indicadoresComparativo.anoRecente}
-                      item={indicadoresComparativo.autorizacoes}
-                      description="Autorizações liberadas para continuidade das contratações."
+                      item={indicadoresComparativo.reconvocacoes}
+                      description="Candidatos que solicitaram participação em nova chamada."
+                    />
+                  </Col>
+                  <Col xs={24} sm={12} lg={6}>
+                    <IndicadorCardComparativo
+                      icon={<PendingActionsIcon fontSize="small" />}
+                      title="Pendentes de escolha"
+                      anoAntigo={indicadoresComparativo.anoAntigo}
+                      anoRecente={indicadoresComparativo.anoRecente}
+                      item={indicadoresComparativo.pendentesEscolha}
+                      description="Convocados que ainda não realizaram a escolha de vaga."
                     />
                   </Col>
                 </>
@@ -513,14 +496,6 @@ const ExtracaoDadosTela: React.FC = () => {
                       title="Habilitados"
                       value={indicadores.habilitados}
                       description="Total de pessoas aprovadas e consideradas aptas no concurso"
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <IndicadorCard
-                      icon={<GroupsIcon fontSize="small" />}
-                      title="Lista específica"
-                      value={indicadores.listaEspecifica}
-                      description="Distribuição de candidatos por lista de classificação"
                       breakdown={[
                         { label: "Geral", value: indicadores.listaGeral },
                         { label: "PCD", value: indicadores.listaPcd },
@@ -538,14 +513,6 @@ const ExtracaoDadosTela: React.FC = () => {
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <IndicadorCard
-                      icon={<HowToRegIcon fontSize="small" />}
-                      title="Escolhas realizadas"
-                      value={indicadores.escolhasRealizadas}
-                      description="Candidatos que realizaram escolha de vaga ou unidade."
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <IndicadorCard
                       icon={<PersonOffIcon fontSize="small" />}
                       title="Não convocados"
                       value={indicadores.naoConvocados}
@@ -554,10 +521,18 @@ const ExtracaoDadosTela: React.FC = () => {
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <IndicadorCard
-                      icon={<ReplayIcon fontSize="small" />}
-                      title="Reconvocações"
-                      value={indicadores.reconvocacoes}
-                      description="Candidatos que solicitaram participação em nova chamada."
+                      icon={<VerifiedUserIcon fontSize="small" />}
+                      title="Autorizações"
+                      value={indicadores.autorizacoes}
+                      description="Autorizações liberadas para continuidade das contratações."
+                    />
+                  </Col>
+                  <Col xs={24} sm={12} lg={6}>
+                    <IndicadorCard
+                      icon={<HowToRegIcon fontSize="small" />}
+                      title="Escolhas realizadas"
+                      value={indicadores.escolhasRealizadas}
+                      description="Candidatos que realizaram escolha de vaga ou unidade."
                     />
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
@@ -570,10 +545,18 @@ const ExtracaoDadosTela: React.FC = () => {
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <IndicadorCard
-                      icon={<VerifiedUserIcon fontSize="small" />}
-                      title="Autorizações"
-                      value={indicadores.autorizacoes}
-                      description="Autorizações liberadas para continuidade das contratações."
+                      icon={<ReplayIcon fontSize="small" />}
+                      title="Reconvocações"
+                      value={indicadores.reconvocacoes}
+                      description="Candidatos que solicitaram participação em nova chamada."
+                    />
+                  </Col>
+                  <Col xs={24} sm={12} lg={6}>
+                    <IndicadorCard
+                      icon={<PendingActionsIcon fontSize="small" />}
+                      title="Pendentes de escolha"
+                      value={indicadores.pendentesEscolha}
+                      description="Convocados que ainda não realizaram a escolha de vaga."
                     />
                   </Col>
                 </>
@@ -642,7 +625,9 @@ const ExtracaoDadosTela: React.FC = () => {
         </TabContentContainer>
       </Spin>
 
-      {/* Versao consolidada renderizada fora da viewport, capturada para o PDF. */}
+      {/* Conteudo renderizado fora da viewport, capturado para o PDF. Reflete o
+          filtro aplicado na tela: comparativo (2 anos) ou simples (sem filtro
+          ou 1 ano). */}
       <div
         ref={pdfRef}
         aria-hidden
@@ -655,16 +640,31 @@ const ExtracaoDadosTela: React.FC = () => {
           padding: "24px",
         }}
       >
-        <ConteudoExtracaoPdf
-          indicadores={indicadoresTodos}
-          graficoEscolhasDre={graficoEscolhasDreTodos}
-          graficoVagasDre={graficoVagasDreTodos}
-          tabelaVagasDre={tabelaVagasDreTodos}
-          relatoriosDetalhados={relatoriosDetalhadosTodos}
-          autorizacoesPublicadas={autorizacoesPublicadasTodos}
-          dataGeracao={dataGeracao}
-          filtroAplicado={filtroAplicado}
-        />
+        {isComparativo && indicadoresComparativo ? (
+          <ConteudoExtracaoPdf
+            isComparativo
+            indicadoresComparativo={indicadoresComparativo}
+            anoAntigo={anoAntigoComparativo}
+            anoRecente={anoRecenteComparativo}
+            dresComparativo={dresComparativo}
+            graficoEscolhasComparativo={graficoEscolhasComparativo}
+            graficoVagasComparativo={graficoVagasComparativo}
+            tabelaVagasDreComparativo={tabelaVagasDreComparativo}
+            relatoriosDetalhados={relatoriosDetalhados}
+            autorizacoesPublicadas={autorizacoesPublicadas}
+            dataGeracao={dataGeracao}
+          />
+        ) : (
+          <ConteudoExtracaoPdf
+            indicadores={indicadores}
+            graficoEscolhasDre={graficoEscolhasDre}
+            graficoVagasDre={graficoVagasDre}
+            tabelaVagasDre={tabelaVagasDre}
+            relatoriosDetalhados={relatoriosDetalhados}
+            autorizacoesPublicadas={autorizacoesPublicadas}
+            dataGeracao={dataGeracao}
+          />
+        )}
       </div>
     </BaseTela>
   );

--- a/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Button, Col, Row, Select, Spin, Typography } from "antd";
 import { BarChartOutlined } from "@ant-design/icons";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -27,6 +27,8 @@ import { useGetExtracaoDadosTodos } from "./hooks/useGetExtracaoDadosTodos";
 import GraficoBarrasDre from "./components/GraficoBarrasDre";
 import TabelaVagasDre from "./components/TabelaVagasDre";
 import RelatoriosDetalhados from "./components/RelatoriosDetalhados";
+import ConteudoExtracaoPdf from "./components/ConteudoExtracaoPdf";
+import { useExportarPdf } from "./hooks/useExportarPdf";
 import {
   mapExtracaoDadosToIndicadores,
   mapExtracaoDadosTodosToIndicadores,
@@ -107,36 +109,62 @@ const ExtracaoDadosTela: React.FC = () => {
       .map((year) => ({ value: year, label: year }));
   }, [processosConvocacaoData]);
 
+  // Variantes consolidadas (todos os concursos). Servem de base tanto para a
+  // tela (quando nao ha filtro aplicado) quanto para o PDF, que e sempre
+  // consolidado independentemente do filtro.
+  const indicadoresTodos = useMemo(
+    () => mapExtracaoDadosTodosToIndicadores(extracaoDadosTodos),
+    [extracaoDadosTodos]
+  );
+  const graficoEscolhasDreTodos = useMemo(
+    () => mapDresTodosParaGraficoEscolhas(extracaoDadosTodos),
+    [extracaoDadosTodos]
+  );
+  const graficoVagasDreTodos = useMemo(
+    () => mapDresTodosParaGraficoVagas(extracaoDadosTodos),
+    [extracaoDadosTodos]
+  );
+  const tabelaVagasDreTodos = useMemo(
+    () => mapDresTodosParaTabela(extracaoDadosTodos),
+    [extracaoDadosTodos]
+  );
+  const relatoriosDetalhadosTodos = useMemo(
+    () => mapDresConcursosParaRelatoriosDetalhados(extracaoDadosTodos, concursosOptions),
+    [extracaoDadosTodos, concursosOptions]
+  );
+
+  // Dados exibidos na tela: filtrados quando ha filtro aplicado, senao usam a
+  // variante consolidada ja calculada acima.
   const indicadores = useMemo(
     () =>
       filtrosAplicados
         ? mapExtracaoDadosToIndicadores(extracaoDados, filtrosAplicados.ano)
-        : mapExtracaoDadosTodosToIndicadores(extracaoDadosTodos),
-    [extracaoDados, extracaoDadosTodos, filtrosAplicados]
+        : indicadoresTodos,
+    [extracaoDados, indicadoresTodos, filtrosAplicados]
   );
 
   const graficoEscolhasDre = useMemo(
     () =>
       filtrosAplicados
         ? mapDresParaGraficoEscolhas(extracaoDados, filtrosAplicados.ano)
-        : mapDresTodosParaGraficoEscolhas(extracaoDadosTodos),
-    [extracaoDados, extracaoDadosTodos, filtrosAplicados]
+        : graficoEscolhasDreTodos,
+    [extracaoDados, graficoEscolhasDreTodos, filtrosAplicados]
   );
 
   const graficoVagasDre = useMemo(
     () =>
       filtrosAplicados
         ? mapDresParaGraficoVagas(extracaoDados, filtrosAplicados.ano)
-        : mapDresTodosParaGraficoVagas(extracaoDadosTodos),
-    [extracaoDados, extracaoDadosTodos, filtrosAplicados]
+        : graficoVagasDreTodos,
+    [extracaoDados, graficoVagasDreTodos, filtrosAplicados]
   );
 
   const tabelaVagasDre = useMemo(
     () =>
       filtrosAplicados
         ? mapDresParaTabela(extracaoDados, filtrosAplicados.ano)
-        : mapDresTodosParaTabela(extracaoDadosTodos),
-    [extracaoDados, extracaoDadosTodos, filtrosAplicados]
+        : tabelaVagasDreTodos,
+    [extracaoDados, tabelaVagasDreTodos, filtrosAplicados]
   );
 
   const relatoriosDetalhados = useMemo(
@@ -148,9 +176,37 @@ const ExtracaoDadosTela: React.FC = () => {
             filtrosAplicados.concurso_uuid,
             concursosOptions
           )
-        : mapDresConcursosParaRelatoriosDetalhados(extracaoDadosTodos, concursosOptions),
-    [extracaoDados, extracaoDadosTodos, filtrosAplicados, concursosOptions]
+        : relatoriosDetalhadosTodos,
+    [extracaoDados, relatoriosDetalhadosTodos, filtrosAplicados, concursosOptions]
   );
+
+  const pdfRef = useRef<HTMLDivElement>(null);
+  const { exportarPdf, isExporting } = useExportarPdf();
+
+  const dataGeracao = useMemo(
+    () => new Date().toLocaleDateString("pt-BR"),
+    []
+  );
+
+  // Descricao do filtro selecionado na tela, exibida no cabecalho do PDF.
+  // Os dados do PDF permanecem consolidados; isto e apenas informativo.
+  const filtroAplicado = useMemo(() => {
+    const partes: string[] = [];
+
+    if (concursoUuid) {
+      const concursoSelecionado = concursosOptions.find(
+        (concurso: { value: string; label: string }) =>
+          concurso.value === concursoUuid
+      );
+      partes.push(`Concurso: ${concursoSelecionado?.label ?? concursoUuid}`);
+    }
+
+    if (ano) {
+      partes.push(`Ano: ${ano}`);
+    }
+
+    return partes.length > 0 ? partes.join(" | ") : undefined;
+  }, [concursoUuid, ano, concursosOptions]);
 
   const canFilter = Boolean(concursoUuid && ano);
 
@@ -197,7 +253,13 @@ const ExtracaoDadosTela: React.FC = () => {
       breadcrumbItems={breadcrumbItems}
       title="Extração de dados"
       buttons={
-        <Button type="primary" size="large" icon={<BarChartOutlined />}>
+        <Button
+          type="primary"
+          size="large"
+          icon={<BarChartOutlined />}
+          loading={isExporting}
+          onClick={() => exportarPdf(pdfRef)}
+        >
           Gerar relatório
         </Button>
       }
@@ -377,6 +439,30 @@ const ExtracaoDadosTela: React.FC = () => {
           <RelatoriosDetalhados data={relatoriosDetalhados} />
         </TabContentContainer>
       </Spin>
+
+      {/* Versao consolidada renderizada fora da viewport, capturada para o PDF. */}
+      <div
+        ref={pdfRef}
+        aria-hidden
+        style={{
+          position: "fixed",
+          left: "-10000px",
+          top: 0,
+          width: "1123px",
+          backgroundColor: "#ffffff",
+          padding: "24px",
+        }}
+      >
+        <ConteudoExtracaoPdf
+          indicadores={indicadoresTodos}
+          graficoEscolhasDre={graficoEscolhasDreTodos}
+          graficoVagasDre={graficoVagasDreTodos}
+          tabelaVagasDre={tabelaVagasDreTodos}
+          relatoriosDetalhados={relatoriosDetalhadosTodos}
+          dataGeracao={dataGeracao}
+          filtroAplicado={filtroAplicado}
+        />
+      </div>
     </BaseTela>
   );
 };

--- a/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/ExtracaoDadosTela.tsx
@@ -27,6 +27,7 @@ import { useGetExtracaoDadosTodos } from "./hooks/useGetExtracaoDadosTodos";
 import GraficoBarrasDre from "./components/GraficoBarrasDre";
 import TabelaVagasDre from "./components/TabelaVagasDre";
 import RelatoriosDetalhados from "./components/RelatoriosDetalhados";
+import AutorizacoesPublicadas from "./components/AutorizacoesPublicadas";
 import ConteudoExtracaoPdf from "./components/ConteudoExtracaoPdf";
 import { useExportarPdf } from "./hooks/useExportarPdf";
 import {
@@ -42,6 +43,7 @@ import {
   mapDresTodosParaTabela,
 } from "./utils/mapGraficosDre";
 import {
+  mapCargosParaAutorizacoesPublicadas,
   mapDresConcursosParaRelatoriosDetalhados,
   mapDresParaRelatoriosDetalhados,
 } from "./utils/mapRelatoriosDetalhados";
@@ -132,6 +134,10 @@ const ExtracaoDadosTela: React.FC = () => {
     () => mapDresConcursosParaRelatoriosDetalhados(extracaoDadosTodos, concursosOptions),
     [extracaoDadosTodos, concursosOptions]
   );
+  const autorizacoesPublicadasTodos = useMemo(
+    () => mapCargosParaAutorizacoesPublicadas(extracaoDadosTodos?.concurso?.cargos),
+    [extracaoDadosTodos]
+  );
 
   // Dados exibidos na tela: filtrados quando ha filtro aplicado, senao usam a
   // variante consolidada ja calculada acima.
@@ -207,6 +213,14 @@ const ExtracaoDadosTela: React.FC = () => {
 
     return partes.length > 0 ? partes.join(" | ") : undefined;
   }, [concursoUuid, ano, concursosOptions]);
+
+  const autorizacoesPublicadas = useMemo(
+    () =>
+      filtrosAplicados
+        ? mapCargosParaAutorizacoesPublicadas(extracaoDados?.concurso?.cargos)
+        : autorizacoesPublicadasTodos,
+    [extracaoDados, autorizacoesPublicadasTodos, filtrosAplicados]
+  );
 
   const canFilter = Boolean(concursoUuid && ano);
 
@@ -437,6 +451,8 @@ const ExtracaoDadosTela: React.FC = () => {
           <TabelaVagasDre data={tabelaVagasDre} />
 
           <RelatoriosDetalhados data={relatoriosDetalhados} />
+
+          <AutorizacoesPublicadas data={autorizacoesPublicadas} />
         </TabContentContainer>
       </Spin>
 
@@ -459,6 +475,7 @@ const ExtracaoDadosTela: React.FC = () => {
           graficoVagasDre={graficoVagasDreTodos}
           tabelaVagasDre={tabelaVagasDreTodos}
           relatoriosDetalhados={relatoriosDetalhadosTodos}
+          autorizacoesPublicadas={autorizacoesPublicadasTodos}
           dataGeracao={dataGeracao}
           filtroAplicado={filtroAplicado}
         />

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/ExtracaoDadosTela.test.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/ExtracaoDadosTela.test.tsx
@@ -88,13 +88,15 @@ describe("ExtracaoDadosTela", () => {
   it("exibe visão consolidada com indicadores e seções principais", () => {
     renderTela();
 
+    // Varios textos aparecem tanto na tela visivel quanto no conteudo oculto
+    // capturado para o PDF (div fora da viewport), por isso usamos getAllBy*.
     expect(screen.getByRole("heading", { name: "Extração de dados" })).toBeInTheDocument();
-    expect(screen.getByText("Indicadores")).toBeInTheDocument();
-    expect(screen.getByText("Habilitados")).toBeInTheDocument();
+    expect(screen.getAllByText("Indicadores").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Habilitados").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1.000").length).toBeGreaterThan(0);
-    expect(screen.getByTestId("grafico-Escolhas por DRE")).toBeInTheDocument();
-    expect(screen.getByText("Relatórios detalhados")).toBeInTheDocument();
-    expect(screen.getByText("Autorizações Publicadas")).toBeInTheDocument();
+    expect(screen.getAllByTestId("grafico-Escolhas por DRE").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Relatórios detalhados").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Autorizações Publicadas").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("cell", { name: "Professor" }).length).toBeGreaterThan(0);
   });
 

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/ExtracaoDadosTela.test.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/ExtracaoDadosTela.test.tsx
@@ -94,7 +94,8 @@ describe("ExtracaoDadosTela", () => {
     expect(screen.getAllByText("1.000").length).toBeGreaterThan(0);
     expect(screen.getByTestId("grafico-Escolhas por DRE")).toBeInTheDocument();
     expect(screen.getByText("Relatórios detalhados")).toBeInTheDocument();
-    expect(screen.getByRole("cell", { name: "Professor" })).toBeInTheDocument();
+    expect(screen.getByText("Autorizações Publicadas")).toBeInTheDocument();
+    expect(screen.getAllByRole("cell", { name: "Professor" }).length).toBeGreaterThan(0);
   });
 
   it("desabilita Filtrar até selecionar concurso e ano", async () => {

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/components/AutorizacoesPublicadas.test.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/components/AutorizacoesPublicadas.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AutorizacoesPublicadas from "../../components/AutorizacoesPublicadas";
+
+describe("AutorizacoesPublicadas", () => {
+  it("renderiza título, colunas e dados da tabela", () => {
+    render(
+      <AutorizacoesPublicadas
+        data={[
+          {
+            key: "cargo-1",
+            cargo: "Analista de Sistemas",
+            quantidade: 32,
+            data_autorizacao: "18/06/2026",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Autorizações Publicadas")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Cargo" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Quantidade" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Última atualização" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Analista de Sistemas")).toBeInTheDocument();
+    expect(screen.getByText("32")).toBeInTheDocument();
+    expect(screen.getByText("18/06/2026")).toBeInTheDocument();
+  });
+
+  it("exibe mensagem de vazio quando não há dados", () => {
+    render(<AutorizacoesPublicadas data={[]} />);
+
+    expect(screen.getByText("Nenhum dado encontrado")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/components/ConteudoExtracaoPdf.test.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/components/ConteudoExtracaoPdf.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ConteudoExtracaoPdf from "../../components/ConteudoExtracaoPdf";
+import {
+  extracaoDadosComparativoMock,
+  extracaoDadosTodosMock,
+} from "../../testFixtures/extracaoDadosFixtures";
+import { mapExtracaoDadosTodosToIndicadores } from "../../utils/mapIndicadores";
+import { mapExtracaoDadosToIndicadoresComparativo } from "../../utils/mapIndicadoresComparativo";
+import {
+  mapDresComparativoPorDre,
+  mapDresParaGraficoComparativo,
+  mapDresParaTabelaComparativo,
+  mapDresTodosParaGraficoEscolhas,
+  mapDresTodosParaGraficoVagas,
+  mapDresTodosParaTabela,
+} from "../../utils/mapGraficosDre";
+import {
+  mapCargosParaAutorizacoesPublicadas,
+  mapConcursoFiltradoParaAutorizacoesPublicadas,
+  mapDresConcursosParaRelatoriosDetalhados,
+  mapDresParaRelatoriosDetalhados,
+} from "../../utils/mapRelatoriosDetalhados";
+
+jest.mock("../../components/GraficoBarrasDre", () => {
+  const { createMockGraficoBarrasDre } = jest.requireActual("../../testHelpers/testMocks");
+
+  return {
+    __esModule: true,
+    default: createMockGraficoBarrasDre(),
+  };
+});
+
+jest.mock("../../components/GraficoBarrasDreComparativo", () => {
+  const { createMockGraficoBarrasDreComparativo } = jest.requireActual(
+    "../../testHelpers/testMocks"
+  );
+
+  return {
+    __esModule: true,
+    default: createMockGraficoBarrasDreComparativo(),
+  };
+});
+
+const concursosOptions = [{ value: "uuid-concurso-1", label: "Concurso Teste 1" }];
+
+const propsSimples = () => ({
+  indicadores: mapExtracaoDadosTodosToIndicadores(extracaoDadosTodosMock),
+  graficoEscolhasDre: mapDresTodosParaGraficoEscolhas(extracaoDadosTodosMock),
+  graficoVagasDre: mapDresTodosParaGraficoVagas(extracaoDadosTodosMock),
+  tabelaVagasDre: mapDresTodosParaTabela(extracaoDadosTodosMock),
+  relatoriosDetalhados: mapDresConcursosParaRelatoriosDetalhados(
+    extracaoDadosTodosMock,
+    concursosOptions
+  ),
+  autorizacoesPublicadas: mapCargosParaAutorizacoesPublicadas(
+    extracaoDadosTodosMock.concurso?.cargos
+  ),
+  dataGeracao: "23/06/2026",
+});
+
+const propsComparativo = () => {
+  const anos = ["2024", "2025"];
+  const indicadoresComparativo = mapExtracaoDadosToIndicadoresComparativo(
+    extracaoDadosComparativoMock,
+    anos
+  )!;
+  const dresComparativo = mapDresComparativoPorDre(extracaoDadosComparativoMock, anos);
+
+  return {
+    isComparativo: true as const,
+    indicadoresComparativo,
+    anoAntigo: "2024",
+    anoRecente: "2025",
+    dresComparativo,
+    graficoEscolhasComparativo: mapDresParaGraficoComparativo(dresComparativo, "escolhas"),
+    graficoVagasComparativo: mapDresParaGraficoComparativo(dresComparativo, "vagas"),
+    tabelaVagasDreComparativo: mapDresParaTabelaComparativo(dresComparativo),
+    relatoriosDetalhados: mapDresParaRelatoriosDetalhados(
+      extracaoDadosComparativoMock,
+      anos,
+      "uuid-concurso-1",
+      concursosOptions
+    ),
+    autorizacoesPublicadas: mapConcursoFiltradoParaAutorizacoesPublicadas(
+      extracaoDadosComparativoMock.concurso,
+      anos
+    ),
+    dataGeracao: "23/06/2026",
+  };
+};
+
+describe("ConteudoExtracaoPdf", () => {
+  it("não exibe a linha 'Filtro aplicado' no formato simples", () => {
+    render(<ConteudoExtracaoPdf {...propsSimples()} />);
+
+    expect(screen.getByRole("heading", { name: "Extração de dados" })).toBeInTheDocument();
+    expect(screen.getByText("Gerado em 23/06/2026")).toBeInTheDocument();
+    expect(screen.queryByText(/Filtro aplicado/i)).not.toBeInTheDocument();
+  });
+
+  it("renderiza as seções do formato simples (sem filtros nos relatórios)", () => {
+    render(<ConteudoExtracaoPdf {...propsSimples()} />);
+
+    expect(screen.getByText("Indicadores")).toBeInTheDocument();
+    expect(screen.getByTestId("grafico-Escolhas por DRE")).toBeInTheDocument();
+    expect(screen.getByTestId("grafico-Total de vagas ofertadas por DRE")).toBeInTheDocument();
+    expect(screen.getByText("Relatórios detalhados")).toBeInTheDocument();
+    expect(screen.getByText("Autorizações Publicadas")).toBeInTheDocument();
+    // mostrarFiltros={false}: nenhum botão de filtro deve aparecer.
+    expect(screen.queryByRole("button", { name: /filtrar/i })).not.toBeInTheDocument();
+  });
+
+  it("renderiza o formato comparativo com gráficos empilhados e sem filtro", () => {
+    render(<ConteudoExtracaoPdf {...propsComparativo()} />);
+
+    expect(screen.queryByText(/Filtro aplicado/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Acompanhe os indicadores nos anos 2025 e 2024\./)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("grafico-comparativo-Escolhas por DRE")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("grafico-comparativo-Total de vagas ofertadas por DRE")
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /filtrar/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/components/RelatoriosDetalhados.test.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/components/RelatoriosDetalhados.test.tsx
@@ -15,8 +15,6 @@ const relatoriosMock: RelatorioDetalhadoItem[] = [
     dreOriginal: "Diretoria Regional de Educação Butantã",
     escolhas: 10,
     naoEscolhas: 5,
-    autorizacoes: 3,
-    data_autorizacao: "15/06/2025",
   },
   {
     key: "2",
@@ -28,8 +26,6 @@ const relatoriosMock: RelatorioDetalhadoItem[] = [
     dreOriginal: "Diretoria Regional de Educação Centro",
     escolhas: 8,
     naoEscolhas: 2,
-    autorizacoes: 1,
-    data_autorizacao: "20/07/2025",
   },
 ];
 
@@ -42,6 +38,15 @@ describe("RelatoriosDetalhados", () => {
     expect(screen.getByRole("cell", { name: "Coordenador" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /filtrar/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /limpar filtros/i })).toBeInTheDocument();
+  });
+
+  it("não exibe mais as colunas de autorização", () => {
+    render(<RelatoriosDetalhados data={relatoriosMock} />);
+
+    expect(screen.queryByRole("columnheader", { name: "Autorizações" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Última atualização" })
+    ).not.toBeInTheDocument();
   });
 
   it("mantém todos os registros ao limpar filtros", async () => {

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapIndicadores.test.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapIndicadores.test.ts
@@ -16,6 +16,7 @@ describe("mapIndicadores", () => {
 
     it("mapeia corretamente os indicadores consolidados", () => {
       expect(mapExtracaoDadosTodosToIndicadores(extracaoDadosTodosMock)).toEqual({
+        modoComparativo: false,
         habilitados: 1000,
         listaEspecifica: 1000,
         listaGeral: 800,
@@ -26,6 +27,8 @@ describe("mapIndicadores", () => {
         naoConvocados: 500,
         reconvocacoes: 50,
         semEscolha: 150,
+        // pendentes = 500 - 300 - 150 - 50 = 0 (clampado)
+        pendentesEscolha: 0,
         autorizacoes: 25,
       });
     });
@@ -33,35 +36,91 @@ describe("mapIndicadores", () => {
 
   describe("mapExtracaoDadosToIndicadores", () => {
     it("retorna indicadores vazios sem dados ou ano", () => {
-      expect(mapExtracaoDadosToIndicadores(undefined, "2024")).toEqual(INDICADORES_VAZIOS);
-      expect(mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, "")).toEqual(
+      expect(mapExtracaoDadosToIndicadores(undefined, ["2024"])).toEqual(
+        INDICADORES_VAZIOS
+      );
+      expect(mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, [])).toEqual(
         INDICADORES_VAZIOS
       );
     });
 
     it("mapeia corretamente os indicadores filtrados por ano", () => {
-      expect(mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, "2024")).toEqual({
-        habilitados: 200,
-        listaEspecifica: 200,
-        listaGeral: 150,
-        listaPcd: 30,
-        listaNna: 20,
-        convocados: 80,
-        escolhasRealizadas: 60,
-        naoConvocados: 120,
-        reconvocacoes: 10,
-        semEscolha: 20,
-        autorizacoes: 8,
-      });
+      expect(mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, ["2024"])).toEqual(
+        {
+          modoComparativo: false,
+          habilitados: 200,
+          listaEspecifica: 200,
+          listaGeral: 150,
+          listaPcd: 30,
+          listaNna: 20,
+          convocados: 80,
+          escolhasRealizadas: 60,
+          naoConvocados: 120,
+          reconvocacoes: 10,
+          semEscolha: 20,
+          // pendentes = 80 - 60 - 20 - 10 = 0 (clampado)
+          pendentesEscolha: 0,
+          autorizacoes: 8,
+        }
+      );
     });
 
     it("retorna zero para ano inexistente nos dados", () => {
-      const indicadores = mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, "2023");
+      const indicadores = mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, [
+        "2023",
+      ]);
 
       expect(indicadores.convocados).toBe(0);
       expect(indicadores.escolhasRealizadas).toBe(0);
-      expect(indicadores.autorizacoes).toBe(8);
+      expect(indicadores.pendentesEscolha).toBe(0);
       expect(indicadores.habilitados).toBe(200);
+    });
+
+    it("calcula pendentes pela fórmula (convocados − escolha − não-escolha − reconvocação)", () => {
+      const dados = {
+        ...extracaoDadosFiltradoMock,
+        candidatos: {
+          ...extracaoDadosFiltradoMock.candidatos,
+          "2024": { convocados: 100, "nao-convocados": 120 },
+        },
+        escolhas: {
+          ...extracaoDadosFiltradoMock.escolhas,
+          "2024": {
+            escolha: 40,
+            reconvocacao: 10,
+            "nao-escolha": 20,
+            dres: [],
+          },
+        },
+      };
+
+      // 100 - 40 - 20 - 10 = 30
+      expect(
+        mapExtracaoDadosToIndicadores(dados, ["2024"]).pendentesEscolha
+      ).toBe(30);
+    });
+
+    it("nunca retorna pendentes negativos (clamp em 0)", () => {
+      const dados = {
+        ...extracaoDadosFiltradoMock,
+        candidatos: {
+          ...extracaoDadosFiltradoMock.candidatos,
+          "2024": { convocados: 10, "nao-convocados": 5 },
+        },
+        escolhas: {
+          ...extracaoDadosFiltradoMock.escolhas,
+          "2024": {
+            escolha: 40,
+            reconvocacao: 10,
+            "nao-escolha": 20,
+            dres: [],
+          },
+        },
+      };
+
+      expect(
+        mapExtracaoDadosToIndicadores(dados, ["2024"]).pendentesEscolha
+      ).toBe(0);
     });
   });
 });

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapRelatoriosDetalhados.test.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapRelatoriosDetalhados.test.ts
@@ -1,10 +1,12 @@
 import {
   mapCargosParaAutorizacoesPublicadas,
+  mapConcursoFiltradoParaAutorizacoesPublicadas,
   mapDresConcursosParaRelatoriosDetalhados,
   mapDresParaRelatoriosDetalhados,
 } from "../../utils/mapRelatoriosDetalhados";
 import {
   concursosOptionsMock,
+  extracaoDadosComparativoMock,
   extracaoDadosFiltradoMock,
   extracaoDadosTodosMock,
 } from "../../testFixtures/extracaoDadosFixtures";
@@ -111,5 +113,77 @@ describe("mapCargosParaAutorizacoesPublicadas", () => {
       quantidade: 3,
       data_autorizacao: "20/07/2025",
     });
+  });
+});
+
+describe("mapConcursoFiltradoParaAutorizacoesPublicadas", () => {
+  it("usa os cargos do bloco do ano selecionado (um ano)", () => {
+    const resultado = mapConcursoFiltradoParaAutorizacoesPublicadas(
+      extracaoDadosFiltradoMock.concurso,
+      ["2024"]
+    );
+
+    expect(resultado).toEqual([
+      {
+        key: "2024-cargo-1",
+        cargo: "Professor",
+        quantidade: 5,
+        data_autorizacao: "10/08/2024",
+      },
+      {
+        key: "2024-cargo-2",
+        cargo: "Coordenador",
+        quantidade: 3,
+        data_autorizacao: "15/09/2024",
+      },
+    ]);
+  });
+
+  it("gera uma linha por cargo de cada ano (comparativo), sem agregar", () => {
+    const resultado = mapConcursoFiltradoParaAutorizacoesPublicadas(
+      extracaoDadosComparativoMock.concurso,
+      ["2024", "2025"]
+    );
+
+    expect(resultado).toEqual([
+      {
+        key: "2024-cargo-1",
+        cargo: "Professor",
+        quantidade: 5,
+        data_autorizacao: "10/08/2024",
+      },
+      {
+        key: "2025-cargo-1",
+        cargo: "Professor",
+        quantidade: 6,
+        data_autorizacao: "10/08/2025",
+      },
+    ]);
+  });
+
+  it("cai para os cargos da raiz quando não há blocos por ano", () => {
+    const resultado = mapConcursoFiltradoParaAutorizacoesPublicadas(
+      extracaoDadosTodosMock.concurso,
+      ["2025"]
+    );
+
+    expect(resultado).toEqual([
+      {
+        key: "cargo-1",
+        cargo: "Professor",
+        quantidade: 5,
+        data_autorizacao: "15/06/2025",
+      },
+      {
+        key: "cargo-2",
+        cargo: "Coordenador",
+        quantidade: 3,
+        data_autorizacao: "20/07/2025",
+      },
+    ]);
+  });
+
+  it("retorna lista vazia quando não há concurso", () => {
+    expect(mapConcursoFiltradoParaAutorizacoesPublicadas(undefined, ["2024"])).toEqual([]);
   });
 });

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapRelatoriosDetalhados.test.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapRelatoriosDetalhados.test.ts
@@ -1,4 +1,5 @@
 import {
+  mapCargosParaAutorizacoesPublicadas,
   mapDresConcursosParaRelatoriosDetalhados,
   mapDresParaRelatoriosDetalhados,
 } from "../../utils/mapRelatoriosDetalhados";
@@ -34,14 +35,10 @@ describe("mapRelatoriosDetalhados", () => {
       dreOriginal: "Diretoria Regional de Educação Butantã",
       escolhas: 10,
       naoEscolhas: 10,
-      autorizacoes: 5,
-      data_autorizacao: "15/06/2025",
     });
     expect(resultado[1]).toMatchObject({
       cargo: "Coordenador",
       naoEscolhas: 10,
-      autorizacoes: 3,
-      data_autorizacao: "20/07/2025",
     });
   });
 
@@ -68,19 +65,51 @@ describe("mapRelatoriosDetalhados", () => {
       dre: "Butantã",
       escolhas: 25,
       naoEscolhas: 15,
-      autorizacoes: 5,
-      data_autorizacao: "10/08/2024",
     });
     expect(resultado[1]).toMatchObject({
       cargo: "Coordenador",
-      autorizacoes: 3,
-      data_autorizacao: "15/09/2024",
     });
+  });
+
+  it("não inclui campos de autorização nos itens de relatórios detalhados", () => {
+    const resultado = mapDresConcursosParaRelatoriosDetalhados(
+      extracaoDadosTodosMock,
+      concursosOptionsMock
+    );
+
+    expect(resultado[0]).not.toHaveProperty("autorizacoes");
+    expect(resultado[0]).not.toHaveProperty("data_autorizacao");
   });
 
   it("retorna lista vazia quando não há dres_concursos para o concurso", () => {
     expect(
       mapDresParaRelatoriosDetalhados(extracaoDadosFiltradoMock, "2024", "uuid-inexistente", [])
     ).toEqual([]);
+  });
+});
+
+describe("mapCargosParaAutorizacoesPublicadas", () => {
+  it("retorna lista vazia quando cargos é undefined", () => {
+    expect(mapCargosParaAutorizacoesPublicadas(undefined)).toEqual([]);
+  });
+
+  it("mapeia cargos para autorizações publicadas formatando a data", () => {
+    const resultado = mapCargosParaAutorizacoesPublicadas(
+      extracaoDadosTodosMock.concurso.cargos
+    );
+
+    expect(resultado).toHaveLength(2);
+    expect(resultado[0]).toEqual({
+      key: "cargo-1",
+      cargo: "Professor",
+      quantidade: 5,
+      data_autorizacao: "15/06/2025",
+    });
+    expect(resultado[1]).toEqual({
+      key: "cargo-2",
+      cargo: "Coordenador",
+      quantidade: 3,
+      data_autorizacao: "20/07/2025",
+    });
   });
 });

--- a/src/pages/Gerenciar/ExtracaoDados/components/AutorizacoesPublicadas.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/AutorizacoesPublicadas.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from "react";
+import type { ColumnsType } from "antd/es/table";
+import { TextTitulo, TextTituloSecundario } from "../../../../components/EstilosCompartilhados";
+import type { AutorizacaoPublicadaItem } from "../utils/mapRelatoriosDetalhados";
+import { RelatoriosDetalhadosTable, TableCard } from "../styles";
+
+type AutorizacoesPublicadasProps = {
+  data: AutorizacaoPublicadaItem[];
+};
+
+const formatNumber = (value: number) => value.toLocaleString("pt-BR");
+
+const AutorizacoesPublicadas: React.FC<AutorizacoesPublicadasProps> = ({ data }) => {
+  const columns = useMemo<ColumnsType<AutorizacaoPublicadaItem>>(
+    () => [
+      {
+        title: "Cargo",
+        dataIndex: "cargo",
+        key: "cargo",
+        ellipsis: true,
+      },
+      {
+        title: "Quantidade",
+        dataIndex: "quantidade",
+        key: "quantidade",
+        width: 140,
+        onCell: () => ({ className: "col-numerica-valor" }),
+        render: (value: number) => formatNumber(value),
+      },
+      {
+        title: "Última atualização",
+        dataIndex: "data_autorizacao",
+        key: "data_autorizacao",
+        width: 180,
+      },
+    ],
+    []
+  );
+
+  return (
+    <TableCard>
+      <TextTitulo style={{ fontSize: 20, marginLeft: 16, display: "block" }}>
+        Autorizações Publicadas
+      </TextTitulo>
+      <TextTituloSecundario style={{ fontSize: 14, marginTop: 8, marginLeft: 16, display: "block" }}>
+        Autorizações publicadas por cargo.
+      </TextTituloSecundario>
+
+      <RelatoriosDetalhadosTable
+        columns={columns}
+        dataSource={data}
+        pagination={false}
+        locale={{ emptyText: "Nenhum dado encontrado" }}
+      />
+    </TableCard>
+  );
+};
+
+export default AutorizacoesPublicadas;

--- a/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
@@ -1,181 +1,343 @@
 import React from "react";
 import { Col, Row } from "antd";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
-import GroupsIcon from "@mui/icons-material/Groups";
 import CampaignIcon from "@mui/icons-material/Campaign";
 import HowToRegIcon from "@mui/icons-material/HowToReg";
 import PersonOffIcon from "@mui/icons-material/PersonOff";
 import ReplayIcon from "@mui/icons-material/Replay";
 import ScheduleIcon from "@mui/icons-material/Schedule";
+import PendingActionsIcon from "@mui/icons-material/PendingActions";
 import VerifiedUserIcon from "@mui/icons-material/VerifiedUser";
 import {
   TextTitulo,
   TextTituloSecundario,
 } from "../../../../components/EstilosCompartilhados";
-import type { IExtracaoDadosIndicadores } from "../../../../services/resources/relatorios/IExtracaoDados";
-import type { DreGraficoItem, TabelaVagasDreItem } from "../utils/mapGraficosDre";
+import type {
+  IExtracaoDadosIndicadores,
+  IExtracaoDadosIndicadoresComparativo,
+} from "../../../../services/resources/relatorios/IExtracaoDados";
+import type {
+  DreComparativoResumo,
+  DreGraficoComparativoItem,
+  DreGraficoItem,
+  TabelaVagasDreComparativoItem,
+  TabelaVagasDreItem,
+} from "../utils/mapGraficosDre";
 import type {
   AutorizacaoPublicadaItem,
   RelatorioDetalhadoItem,
 } from "../utils/mapRelatoriosDetalhados";
 import IndicadorCard from "./IndicadorCard";
+import IndicadorCardComparativo from "./IndicadorCardComparativo";
 import GraficoBarrasDre from "./GraficoBarrasDre";
+import GraficoBarrasDreComparativo from "./GraficoBarrasDreComparativo";
 import TabelaVagasDre from "./TabelaVagasDre";
 import RelatoriosDetalhados from "./RelatoriosDetalhados";
 import AutorizacoesPublicadas from "./AutorizacoesPublicadas";
 import { IndicatorsCard, PdfHeader } from "../styles";
 
-export type ConteudoExtracaoPdfProps = {
+type ConteudoExtracaoPdfPropsBase = {
+  relatoriosDetalhados: RelatorioDetalhadoItem[];
+  autorizacoesPublicadas: AutorizacaoPublicadaItem[];
+  dataGeracao: string;
+};
+
+type ConteudoExtracaoPdfPropsSimples = ConteudoExtracaoPdfPropsBase & {
+  isComparativo?: false;
   indicadores: IExtracaoDadosIndicadores;
   graficoEscolhasDre: DreGraficoItem[];
   graficoVagasDre: DreGraficoItem[];
   tabelaVagasDre: TabelaVagasDreItem[];
-  relatoriosDetalhados: RelatorioDetalhadoItem[];
-  autorizacoesPublicadas: AutorizacaoPublicadaItem[];
-  dataGeracao: string;
-  filtroAplicado?: string;
 };
+
+type ConteudoExtracaoPdfPropsComparativo = ConteudoExtracaoPdfPropsBase & {
+  isComparativo: true;
+  indicadoresComparativo: IExtracaoDadosIndicadoresComparativo;
+  anoAntigo: string;
+  anoRecente: string;
+  dresComparativo: DreComparativoResumo[];
+  graficoEscolhasComparativo: DreGraficoComparativoItem[];
+  graficoVagasComparativo: DreGraficoComparativoItem[];
+  tabelaVagasDreComparativo: TabelaVagasDreComparativoItem[];
+};
+
+export type ConteudoExtracaoPdfProps =
+  | ConteudoExtracaoPdfPropsSimples
+  | ConteudoExtracaoPdfPropsComparativo;
 
 /**
  * Versao "somente conteudo" da tela de Extracao de Dados, usada para gerar o
- * PDF. Renderiza indicadores, graficos e tabelas sem nenhum filtro, header ou
- * menu. Cada bloco capturavel recebe o atributo `data-pdf-section` para que o
- * hook de exportacao consiga iterar e paginar cada secao individualmente.
+ * PDF. Renderiza indicadores, graficos e tabelas sem nenhum filtro, header de
+ * tela ou menu. Suporta os dois formatos da tela: simples (sem filtro ou 1 ano)
+ * e comparativo com estatisticas (2 anos selecionados). Cada bloco capturavel
+ * recebe o atributo `data-pdf-section` para que o hook de exportacao consiga
+ * iterar e paginar cada secao individualmente.
  */
-const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = ({
-  indicadores,
-  graficoEscolhasDre,
-  graficoVagasDre,
-  tabelaVagasDre,
-  relatoriosDetalhados,
-  autorizacoesPublicadas,
-  dataGeracao,
-  filtroAplicado,
-}) => (
-  <div>
-    <div data-pdf-section>
-      <PdfHeader>
-        <h1>Extração de dados</h1>
-        <span>Gerado em {dataGeracao}</span>
-        <span>Filtro aplicado: {filtroAplicado ?? "Todos os concursos"}</span>
-      </PdfHeader>
+const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
+  const { relatoriosDetalhados, autorizacoesPublicadas, dataGeracao } = props;
 
-      <IndicatorsCard>
-        <Row>
-        <Col span={24}>
-          <TextTitulo style={{ fontSize: 20, display: "block" }}>Indicadores</TextTitulo>
-          <TextTituloSecundario style={{ fontSize: 14, marginTop: 8, display: "block" }}>
-            Acompanhe os indicadores, convocações, escolhas e dados consolidados dos concursos públicos.
-          </TextTituloSecundario>
-        </Col>
-      </Row>
+  return (
+    <div>
+      <div data-pdf-section>
+        <PdfHeader>
+          <h1>Extração de dados</h1>
+          <span>Gerado em {dataGeracao}</span>
+        </PdfHeader>
 
-      <Row gutter={[16, 16]} style={{ marginTop: "1.5rem" }}>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<TaskAltIcon fontSize="small" />}
-            title="Habilitados"
-            value={indicadores.habilitados}
-            description="Total de pessoas aprovadas e consideradas aptas no concurso"
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<GroupsIcon fontSize="small" />}
-            title="Lista específica"
-            value={indicadores.listaEspecifica}
-            description="Distribuição de candidatos por lista de classificação"
-            breakdown={[
-              { label: "Geral", value: indicadores.listaGeral },
-              { label: "PCD", value: indicadores.listaPcd },
-              { label: "NNA", value: indicadores.listaNna },
-            ]}
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<CampaignIcon fontSize="small" />}
-            title="Convocados"
-            value={indicadores.convocados}
-            description="Total de candidatos chamados oficialmente."
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<HowToRegIcon fontSize="small" />}
-            title="Escolhas realizadas"
-            value={indicadores.escolhasRealizadas}
-            description="Candidatos que realizaram escolha de vaga ou unidade."
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<PersonOffIcon fontSize="small" />}
-            title="Não convocados"
-            value={indicadores.naoConvocados}
-            description="Habilitados que ainda não foram convocados."
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<ReplayIcon fontSize="small" />}
-            title="Reconvocações"
-            value={indicadores.reconvocacoes}
-            description="Candidatos que solicitaram participação em nova chamada."
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<ScheduleIcon fontSize="small" />}
-            title="Não escolha"
-            value={indicadores.semEscolha}
-            description="Convocados que decidiram pela não escolha."
-          />
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <IndicadorCard
-            icon={<VerifiedUserIcon fontSize="small" />}
-            title="Autorizações"
-            value={indicadores.autorizacoes}
-            description="Autorizações liberadas para continuidade das contratações."
-          />
-        </Col>
-      </Row>
-      </IndicatorsCard>
+        <IndicatorsCard>
+          <Row>
+            <Col span={24}>
+              <TextTitulo style={{ fontSize: 20, display: "block" }}>Indicadores</TextTitulo>
+              <TextTituloSecundario style={{ fontSize: 14, marginTop: 8, display: "block" }}>
+                Acompanhe os indicadores, convocações, escolhas e dados consolidados dos concursos públicos.
+              </TextTituloSecundario>
+              {props.isComparativo && (
+                <TextTituloSecundario
+                  style={{ fontSize: 14, marginTop: 8, display: "block", fontWeight: 600 }}
+                >
+                  Acompanhe os indicadores nos anos {props.indicadoresComparativo.anoRecente} e{" "}
+                  {props.indicadoresComparativo.anoAntigo}.
+                </TextTituloSecundario>
+              )}
+            </Col>
+          </Row>
+
+          <Row gutter={[16, 16]} style={{ marginTop: "1.5rem" }}>
+            {props.isComparativo ? (
+              <>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<TaskAltIcon fontSize="small" />}
+                    title="Habilitados"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.habilitados}
+                    breakdown={props.indicadoresComparativo.listaEspecifica.breakdown}
+                    modoValorUnico
+                    description="Total de pessoas aprovadas e consideradas aptas no concurso"
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<CampaignIcon fontSize="small" />}
+                    title="Convocados"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.convocados}
+                    description="Total de candidatos chamados oficialmente."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<PersonOffIcon fontSize="small" />}
+                    title="Não convocados"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.naoConvocados}
+                    description="Habilitados que ainda não foram convocados."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<VerifiedUserIcon fontSize="small" />}
+                    title="Autorizações"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.autorizacoes}
+                    description="Autorizações liberadas para continuidade das contratações."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<HowToRegIcon fontSize="small" />}
+                    title="Escolhas realizadas"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.escolhasRealizadas}
+                    description="Candidatos que realizaram escolha de vaga ou unidade."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<ScheduleIcon fontSize="small" />}
+                    title="Não escolha"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.semEscolha}
+                    description="Convocados que decidiram pela não escolha."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<ReplayIcon fontSize="small" />}
+                    title="Reconvocações"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.reconvocacoes}
+                    description="Candidatos que solicitaram participação em nova chamada."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCardComparativo
+                    icon={<PendingActionsIcon fontSize="small" />}
+                    title="Pendentes de escolha"
+                    anoAntigo={props.indicadoresComparativo.anoAntigo}
+                    anoRecente={props.indicadoresComparativo.anoRecente}
+                    item={props.indicadoresComparativo.pendentesEscolha}
+                    description="Convocados que ainda não realizaram a escolha de vaga."
+                  />
+                </Col>
+              </>
+            ) : (
+              <>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<TaskAltIcon fontSize="small" />}
+                    title="Habilitados"
+                    value={props.indicadores.habilitados}
+                    description="Total de pessoas aprovadas e consideradas aptas no concurso"
+                    breakdown={[
+                      { label: "Geral", value: props.indicadores.listaGeral },
+                      { label: "PCD", value: props.indicadores.listaPcd },
+                      { label: "NNA", value: props.indicadores.listaNna },
+                    ]}
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<CampaignIcon fontSize="small" />}
+                    title="Convocados"
+                    value={props.indicadores.convocados}
+                    description="Total de candidatos chamados oficialmente."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<PersonOffIcon fontSize="small" />}
+                    title="Não convocados"
+                    value={props.indicadores.naoConvocados}
+                    description="Habilitados que ainda não foram convocados."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<VerifiedUserIcon fontSize="small" />}
+                    title="Autorizações"
+                    value={props.indicadores.autorizacoes}
+                    description="Autorizações liberadas para continuidade das contratações."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<HowToRegIcon fontSize="small" />}
+                    title="Escolhas realizadas"
+                    value={props.indicadores.escolhasRealizadas}
+                    description="Candidatos que realizaram escolha de vaga ou unidade."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<ScheduleIcon fontSize="small" />}
+                    title="Não escolha"
+                    value={props.indicadores.semEscolha}
+                    description="Convocados que decidiram pela não escolha."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<ReplayIcon fontSize="small" />}
+                    title="Reconvocações"
+                    value={props.indicadores.reconvocacoes}
+                    description="Candidatos que solicitaram participação em nova chamada."
+                  />
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <IndicadorCard
+                    icon={<PendingActionsIcon fontSize="small" />}
+                    title="Pendentes de escolha"
+                    value={props.indicadores.pendentesEscolha}
+                    description="Convocados que ainda não realizaram a escolha de vaga."
+                  />
+                </Col>
+              </>
+            )}
+          </Row>
+        </IndicatorsCard>
+      </div>
+
+      {props.isComparativo ? (
+        <>
+          <div data-pdf-section data-pdf-chart>
+            <GraficoBarrasDreComparativo
+              title="Escolhas por DRE"
+              subtitle={`Distribuição de escolhas consolidadas por DRE nos anos ${props.anoRecente} e ${props.anoAntigo}.`}
+              data={props.graficoEscolhasComparativo}
+              resumos={props.dresComparativo}
+              tooltipLabel="escolhas"
+              corAnoAntigo="#002C8C"
+              corAnoRecente="#F5A623"
+              layoutBarras="empilhado"
+              exibirTituloDreNoTooltip
+            />
+          </div>
+
+          <div data-pdf-section data-pdf-chart>
+            <GraficoBarrasDreComparativo
+              title="Total de vagas ofertadas por DRE"
+              subtitle={`Comparativo de vagas disponibilizadas em cada DRE nos anos ${props.anoRecente} e ${props.anoAntigo}.`}
+              data={props.graficoVagasComparativo}
+              resumos={props.dresComparativo}
+              tooltipLabel="vagas"
+              corAnoAntigo="#0F59C8"
+              corAnoRecente="#F5A623"
+              layoutBarras="empilhado"
+            />
+          </div>
+
+          <div data-pdf-section>
+            <TabelaVagasDre
+              dataComparativo={props.tabelaVagasDreComparativo}
+              subtitle={`Tabela com escolhas e percentual de preenchimento nos anos ${props.anoRecente} e ${props.anoAntigo}.`}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div data-pdf-section data-pdf-chart>
+            <GraficoBarrasDre
+              title="Escolhas por DRE"
+              subtitle="Distribuição de escolhas consolidadas por DRE."
+              data={props.graficoEscolhasDre}
+              tooltipLabel="escolhas"
+              barColor="#002C8C"
+            />
+          </div>
+
+          <div data-pdf-section data-pdf-chart>
+            <GraficoBarrasDre
+              title="Total de vagas ofertadas por DRE"
+              subtitle="Comparativo de vagas disponibilizadas em cada DRE."
+              data={props.graficoVagasDre}
+              tooltipLabel="vagas"
+              barColor="#0F59C8"
+            />
+          </div>
+
+          <div data-pdf-section>
+            <TabelaVagasDre data={props.tabelaVagasDre} />
+          </div>
+        </>
+      )}
+
+      <div data-pdf-section>
+        <RelatoriosDetalhados data={relatoriosDetalhados} mostrarFiltros={false} />
+      </div>
+
+      <div data-pdf-section>
+        <AutorizacoesPublicadas data={autorizacoesPublicadas} />
+      </div>
     </div>
-
-    <div data-pdf-section data-pdf-chart>
-      <GraficoBarrasDre
-        title="Escolhas por DRE"
-        subtitle="Distribuição de escolhas consolidadas por DRE."
-        data={graficoEscolhasDre}
-        tooltipLabel="escolhas"
-        barColor="#002C8C"
-      />
-    </div>
-
-    <div data-pdf-section data-pdf-chart>
-      <GraficoBarrasDre
-        title="Total de vagas ofertadas por DRE"
-        subtitle="Comparativo de vagas disponibilizadas em cada DRE."
-        data={graficoVagasDre}
-        tooltipLabel="vagas"
-        barColor="#0F59C8"
-      />
-    </div>
-
-    <div data-pdf-section>
-      <TabelaVagasDre data={tabelaVagasDre} />
-    </div>
-
-    <div data-pdf-section>
-      <RelatoriosDetalhados data={relatoriosDetalhados} mostrarFiltros={false} />
-    </div>
-
-    <div data-pdf-section>
-      <AutorizacoesPublicadas data={autorizacoesPublicadas} />
-    </div>
-  </div>
-);
+  );
+};
 
 export default ConteudoExtracaoPdf;

--- a/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
@@ -105,7 +105,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
           <Row gutter={[16, 16]} style={{ marginTop: "1.5rem" }}>
             {props.isComparativo ? (
               <>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<TaskAltIcon fontSize="small" />}
                     title="Habilitados"
@@ -117,7 +117,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Total de pessoas aprovadas e consideradas aptas no concurso"
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<CampaignIcon fontSize="small" />}
                     title="Convocados"
@@ -127,7 +127,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Total de candidatos chamados oficialmente."
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<PersonOffIcon fontSize="small" />}
                     title="Não convocados"
@@ -137,7 +137,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Habilitados que ainda não foram convocados."
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<VerifiedUserIcon fontSize="small" />}
                     title="Autorizações"
@@ -147,7 +147,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Autorizações liberadas para continuidade das contratações."
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<HowToRegIcon fontSize="small" />}
                     title="Escolhas realizadas"
@@ -157,7 +157,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Candidatos que realizaram escolha de vaga ou unidade."
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<ScheduleIcon fontSize="small" />}
                     title="Não escolha"
@@ -167,7 +167,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Convocados que decidiram pela não escolha."
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<ReplayIcon fontSize="small" />}
                     title="Reconvocações"
@@ -177,7 +177,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = (props) => {
                     description="Candidatos que solicitaram participação em nova chamada."
                   />
                 </Col>
-                <Col xs={24} sm={12} lg={6}>
+                <Col xs={24} sm={12} lg={8}>
                   <IndicadorCardComparativo
                     icon={<PendingActionsIcon fontSize="small" />}
                     title="Pendentes de escolha"

--- a/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { Col, Row } from "antd";
+import TaskAltIcon from "@mui/icons-material/TaskAlt";
+import GroupsIcon from "@mui/icons-material/Groups";
+import CampaignIcon from "@mui/icons-material/Campaign";
+import HowToRegIcon from "@mui/icons-material/HowToReg";
+import PersonOffIcon from "@mui/icons-material/PersonOff";
+import ReplayIcon from "@mui/icons-material/Replay";
+import ScheduleIcon from "@mui/icons-material/Schedule";
+import VerifiedUserIcon from "@mui/icons-material/VerifiedUser";
+import {
+  TextTitulo,
+  TextTituloSecundario,
+} from "../../../../components/EstilosCompartilhados";
+import type { IExtracaoDadosIndicadores } from "../../../../services/resources/relatorios/IExtracaoDados";
+import type { DreGraficoItem, TabelaVagasDreItem } from "../utils/mapGraficosDre";
+import type { RelatorioDetalhadoItem } from "../utils/mapRelatoriosDetalhados";
+import IndicadorCard from "./IndicadorCard";
+import GraficoBarrasDre from "./GraficoBarrasDre";
+import TabelaVagasDre from "./TabelaVagasDre";
+import RelatoriosDetalhados from "./RelatoriosDetalhados";
+import { IndicatorsCard, PdfHeader } from "../styles";
+
+export type ConteudoExtracaoPdfProps = {
+  indicadores: IExtracaoDadosIndicadores;
+  graficoEscolhasDre: DreGraficoItem[];
+  graficoVagasDre: DreGraficoItem[];
+  tabelaVagasDre: TabelaVagasDreItem[];
+  relatoriosDetalhados: RelatorioDetalhadoItem[];
+  dataGeracao: string;
+  filtroAplicado?: string;
+};
+
+/**
+ * Versao "somente conteudo" da tela de Extracao de Dados, usada para gerar o
+ * PDF. Renderiza indicadores, graficos e tabelas sem nenhum filtro, header ou
+ * menu. Cada bloco capturavel recebe o atributo `data-pdf-section` para que o
+ * hook de exportacao consiga iterar e paginar cada secao individualmente.
+ */
+const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = ({
+  indicadores,
+  graficoEscolhasDre,
+  graficoVagasDre,
+  tabelaVagasDre,
+  relatoriosDetalhados,
+  dataGeracao,
+  filtroAplicado,
+}) => (
+  <div>
+    <div data-pdf-section>
+      <PdfHeader>
+        <h1>Extração de dados</h1>
+        <span>Gerado em {dataGeracao}</span>
+        <span>Filtro aplicado: {filtroAplicado ?? "Todos os concursos"}</span>
+      </PdfHeader>
+
+      <IndicatorsCard>
+        <Row>
+        <Col span={24}>
+          <TextTitulo style={{ fontSize: 20, display: "block" }}>Indicadores</TextTitulo>
+          <TextTituloSecundario style={{ fontSize: 14, marginTop: 8, display: "block" }}>
+            Acompanhe os indicadores, convocações, escolhas e dados consolidados dos concursos públicos.
+          </TextTituloSecundario>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]} style={{ marginTop: "1.5rem" }}>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<TaskAltIcon fontSize="small" />}
+            title="Habilitados"
+            value={indicadores.habilitados}
+            description="Total de pessoas aprovadas e consideradas aptas no concurso"
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<GroupsIcon fontSize="small" />}
+            title="Lista específica"
+            value={indicadores.listaEspecifica}
+            description="Distribuição de candidatos por lista de classificação"
+            breakdown={[
+              { label: "Geral", value: indicadores.listaGeral },
+              { label: "PCD", value: indicadores.listaPcd },
+              { label: "NNA", value: indicadores.listaNna },
+            ]}
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<CampaignIcon fontSize="small" />}
+            title="Convocados"
+            value={indicadores.convocados}
+            description="Total de candidatos chamados oficialmente."
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<HowToRegIcon fontSize="small" />}
+            title="Escolhas realizadas"
+            value={indicadores.escolhasRealizadas}
+            description="Candidatos que realizaram escolha de vaga ou unidade."
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<PersonOffIcon fontSize="small" />}
+            title="Não convocados"
+            value={indicadores.naoConvocados}
+            description="Habilitados que ainda não foram convocados."
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<ReplayIcon fontSize="small" />}
+            title="Reconvocações"
+            value={indicadores.reconvocacoes}
+            description="Candidatos que solicitaram participação em nova chamada."
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<ScheduleIcon fontSize="small" />}
+            title="Não escolha"
+            value={indicadores.semEscolha}
+            description="Convocados que decidiram pela não escolha."
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <IndicadorCard
+            icon={<VerifiedUserIcon fontSize="small" />}
+            title="Autorizações"
+            value={indicadores.autorizacoes}
+            description="Autorizações liberadas para continuidade das contratações."
+          />
+        </Col>
+      </Row>
+      </IndicatorsCard>
+    </div>
+
+    <div data-pdf-section data-pdf-chart>
+      <GraficoBarrasDre
+        title="Escolhas por DRE"
+        subtitle="Distribuição de escolhas consolidadas por DRE."
+        data={graficoEscolhasDre}
+        tooltipLabel="escolhas"
+        barColor="#002C8C"
+      />
+    </div>
+
+    <div data-pdf-section data-pdf-chart>
+      <GraficoBarrasDre
+        title="Total de vagas ofertadas por DRE"
+        subtitle="Comparativo de vagas disponibilizadas em cada DRE."
+        data={graficoVagasDre}
+        tooltipLabel="vagas"
+        barColor="#0F59C8"
+      />
+    </div>
+
+    <div data-pdf-section>
+      <TabelaVagasDre data={tabelaVagasDre} />
+    </div>
+
+    <div data-pdf-section>
+      <RelatoriosDetalhados data={relatoriosDetalhados} mostrarFiltros={false} />
+    </div>
+  </div>
+);
+
+export default ConteudoExtracaoPdf;

--- a/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/ConteudoExtracaoPdf.tsx
@@ -14,11 +14,15 @@ import {
 } from "../../../../components/EstilosCompartilhados";
 import type { IExtracaoDadosIndicadores } from "../../../../services/resources/relatorios/IExtracaoDados";
 import type { DreGraficoItem, TabelaVagasDreItem } from "../utils/mapGraficosDre";
-import type { RelatorioDetalhadoItem } from "../utils/mapRelatoriosDetalhados";
+import type {
+  AutorizacaoPublicadaItem,
+  RelatorioDetalhadoItem,
+} from "../utils/mapRelatoriosDetalhados";
 import IndicadorCard from "./IndicadorCard";
 import GraficoBarrasDre from "./GraficoBarrasDre";
 import TabelaVagasDre from "./TabelaVagasDre";
 import RelatoriosDetalhados from "./RelatoriosDetalhados";
+import AutorizacoesPublicadas from "./AutorizacoesPublicadas";
 import { IndicatorsCard, PdfHeader } from "../styles";
 
 export type ConteudoExtracaoPdfProps = {
@@ -27,6 +31,7 @@ export type ConteudoExtracaoPdfProps = {
   graficoVagasDre: DreGraficoItem[];
   tabelaVagasDre: TabelaVagasDreItem[];
   relatoriosDetalhados: RelatorioDetalhadoItem[];
+  autorizacoesPublicadas: AutorizacaoPublicadaItem[];
   dataGeracao: string;
   filtroAplicado?: string;
 };
@@ -43,6 +48,7 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = ({
   graficoVagasDre,
   tabelaVagasDre,
   relatoriosDetalhados,
+  autorizacoesPublicadas,
   dataGeracao,
   filtroAplicado,
 }) => (
@@ -164,6 +170,10 @@ const ConteudoExtracaoPdf: React.FC<ConteudoExtracaoPdfProps> = ({
 
     <div data-pdf-section>
       <RelatoriosDetalhados data={relatoriosDetalhados} mostrarFiltros={false} />
+    </div>
+
+    <div data-pdf-section>
+      <AutorizacoesPublicadas data={autorizacoesPublicadas} />
     </div>
   </div>
 );

--- a/src/pages/Gerenciar/ExtracaoDados/components/RelatoriosDetalhados.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/RelatoriosDetalhados.tsx
@@ -31,25 +31,6 @@ const TODAS_DRES = "todas";
 
 const formatNumber = (value: number) => value.toLocaleString("pt-BR");
 
-const renderUltimaAtualizacao = (valor: string) => {
-  if (!valor || valor === "-") {
-    return "-";
-  }
-
-  const [data, hora] = valor.split(" ");
-
-  if (!hora) {
-    return valor;
-  }
-
-  return (
-    <span style={{ display: "inline-flex", flexDirection: "column", lineHeight: 1.35 }}>
-      <span>{data}</span>
-      <span>{hora}</span>
-    </span>
-  );
-};
-
 const renderValorComDetalheAnos = (
   value: number,
   detalhePorAno: RelatorioDetalhadoItem["detalhePorAno"],
@@ -152,35 +133,6 @@ const RelatoriosDetalhados: React.FC<RelatoriosDetalhadosProps> = ({
         onCell: () => ({ className: "col-numerica-valor" }),
         render: (value: number, record) =>
           renderValorComDetalheAnos(value, record.detalhePorAno, "escolhas"),
-      },
-      {
-        title: "Não Escolhas",
-        dataIndex: "naoEscolhas",
-        key: "naoEscolhas",
-        width: 130,
-        align: "center",
-        onCell: () => ({ className: "col-numerica-valor" }),
-        render: (value: number, record) =>
-          renderValorComDetalheAnos(value, record.detalhePorAno, "naoEscolhas"),
-      },
-      {
-        title: "Autorizações",
-        dataIndex: "autorizacoes",
-        key: "autorizacoes",
-        width: 145,
-        align: "center",
-        onHeaderCell: () => ({ style: { whiteSpace: "nowrap" } }),
-        onCell: () => ({ className: "col-numerica-valor" }),
-        render: (value: number, record) =>
-          renderValorComDetalheAnos(value, record.detalhePorAno, "autorizacoes"),
-      },
-      {
-        title: "Última atualização",
-        dataIndex: "data_autorizacao",
-        key: "data_autorizacao",
-        width: 140,
-        align: "center",
-        render: (value: string) => renderUltimaAtualizacao(value),
       },
     ],
     []

--- a/src/pages/Gerenciar/ExtracaoDados/components/RelatoriosDetalhados.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/RelatoriosDetalhados.tsx
@@ -102,20 +102,6 @@ const RelatoriosDetalhados: React.FC<RelatoriosDetalhadosProps> = ({
         onCell: () => ({ className: "col-numerica-valor" }),
         render: (value: number) => formatNumber(value),
       },
-      {
-        title: "Autorizações",
-        dataIndex: "autorizacoes",
-        key: "autorizacoes",
-        width: 140,
-        onCell: () => ({ className: "col-numerica-valor" }),
-        render: (value: number) => formatNumber(value),
-      },
-      {
-        title: "Última atualização",
-        dataIndex: "data_autorizacao",
-        key: "data_autorizacao",
-        width: 180,
-      },
     ],
     []
   );

--- a/src/pages/Gerenciar/ExtracaoDados/components/RelatoriosDetalhados.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/components/RelatoriosDetalhados.tsx
@@ -18,6 +18,7 @@ import {
 
 type RelatoriosDetalhadosProps = {
   data: RelatorioDetalhadoItem[];
+  mostrarFiltros?: boolean;
 };
 
 const TODOS_CARGOS = "todos";
@@ -25,7 +26,10 @@ const TODAS_DRES = "todas";
 
 const formatNumber = (value: number) => value.toLocaleString("pt-BR");
 
-const RelatoriosDetalhados: React.FC<RelatoriosDetalhadosProps> = ({ data }) => {
+const RelatoriosDetalhados: React.FC<RelatoriosDetalhadosProps> = ({
+  data,
+  mostrarFiltros = true,
+}) => {
   const [cargo, setCargo] = useState<string>(TODOS_CARGOS);
   const [dre, setDre] = useState<string>(TODAS_DRES);
   const [cargoAplicado, setCargoAplicado] = useState<string>(TODOS_CARGOS);
@@ -157,55 +161,59 @@ const RelatoriosDetalhados: React.FC<RelatoriosDetalhadosProps> = ({ data }) => 
         Lista consolidada por concurso, cargo e DRE.
       </TextTituloSecundario>
 
-      <RelatoriosDetalhadosFilter>
-        <Row gutter={24}>
-          <Col xs={24} md={12}>
-            <CustomFormItem label="Cargo" labelCol={{ span: 24 }}>
-              <StyledSelect
-                value={cargo}
-                onChange={(value) => setCargo(value as string)}
-                suffixIcon={<ExpandMoreIcon style={{ fontSize: "1.5rem", color: "#032B68" }} />}
-              >
-                {cargoOptions.map((option) => (
-                  <Select.Option key={option.value} value={option.value}>
-                    {option.label}
-                  </Select.Option>
-                ))}
-              </StyledSelect>
-            </CustomFormItem>
-          </Col>
-          <Col xs={24} md={12}>
-            <CustomFormItem label="DRE" labelCol={{ span: 24 }}>
-              <StyledSelect
-                value={dre}
-                onChange={(value) => setDre(value as string)}
-                suffixIcon={<ExpandMoreIcon style={{ fontSize: "1.5rem", color: "#032B68" }} />}
-              >
-                {dreOptions.map((option) => (
-                  <Select.Option key={option.value} value={option.value}>
-                    {option.label}
-                  </Select.Option>
-                ))}
-              </StyledSelect>
-            </CustomFormItem>
-          </Col>
-        </Row>
+      {mostrarFiltros && (
+        <>
+          <RelatoriosDetalhadosFilter>
+            <Row gutter={24}>
+              <Col xs={24} md={12}>
+                <CustomFormItem label="Cargo" labelCol={{ span: 24 }}>
+                  <StyledSelect
+                    value={cargo}
+                    onChange={(value) => setCargo(value as string)}
+                    suffixIcon={<ExpandMoreIcon style={{ fontSize: "1.5rem", color: "#032B68" }} />}
+                  >
+                    {cargoOptions.map((option) => (
+                      <Select.Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Select.Option>
+                    ))}
+                  </StyledSelect>
+                </CustomFormItem>
+              </Col>
+              <Col xs={24} md={12}>
+                <CustomFormItem label="DRE" labelCol={{ span: 24 }}>
+                  <StyledSelect
+                    value={dre}
+                    onChange={(value) => setDre(value as string)}
+                    suffixIcon={<ExpandMoreIcon style={{ fontSize: "1.5rem", color: "#032B68" }} />}
+                  >
+                    {dreOptions.map((option) => (
+                      <Select.Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Select.Option>
+                    ))}
+                  </StyledSelect>
+                </CustomFormItem>
+              </Col>
+            </Row>
 
-      </RelatoriosDetalhadosFilter>
+          </RelatoriosDetalhadosFilter>
 
-      <FilterActions style={{ marginTop: 20 }}>
-        <Button type="primary" ghost size="large" onClick={handleLimparFiltros}>
-          Limpar filtros
-        </Button>
-        <Button type="primary" size="large" onClick={handleFiltrar}>
-          Filtrar
-        </Button>
-      </FilterActions>
+          <FilterActions style={{ marginTop: 20 }}>
+            <Button type="primary" ghost size="large" onClick={handleLimparFiltros}>
+              Limpar filtros
+            </Button>
+            <Button type="primary" size="large" onClick={handleFiltrar}>
+              Filtrar
+            </Button>
+          </FilterActions>
+        </>
+      )}
 
       <RelatoriosDetalhadosTable
         columns={columns}
-        dataSource={dadosPaginados}
-        pagination={pagination}
+        dataSource={mostrarFiltros ? dadosPaginados : dadosFiltrados}
+        pagination={mostrarFiltros ? pagination : false}
         locale={{ emptyText: "Nenhum dado encontrado" }}
       />
     </TableCard>

--- a/src/pages/Gerenciar/ExtracaoDados/hooks/useExportarPdf.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/hooks/useExportarPdf.ts
@@ -117,11 +117,18 @@ export const useExportarPdf = () => {
             cursorY = MARGEM_MM;
           }
 
-          // Secao mais alta que uma pagina inteira: fatia em paginas.
+          // Secao mais alta que uma pagina inteira: fatia em paginas. Cada
+          // fatia ocupa uma pagina propria; so adicionamos uma nova pagina
+          // ENTRE fatias, nunca depois da ultima, para nao deixar pagina em
+          // branco no final.
           if (alturaMm > CONTEUDO_ALTURA_MM) {
             const escala = CONTEUDO_LARGURA_MM / larguraPx;
             const paginaAlturaPx = CONTEUDO_ALTURA_MM / escala;
             let offsetPx = 0;
+
+            // A verificacao de quebra (acima) ja garante que comecamos no topo
+            // de uma pagina sem conteudo quando necessario.
+            cursorY = MARGEM_MM;
 
             while (offsetPx < alturaPx) {
               const fatiaAlturaPx = Math.min(
@@ -160,11 +167,6 @@ export const useExportarPdf = () => {
 
               const fatiaAlturaMm = fatiaAlturaPx * escala;
 
-              if (cursorY > MARGEM_MM) {
-                doc.addPage();
-                cursorY = MARGEM_MM;
-              }
-
               doc.addImage(
                 fatiaCanvas.toDataURL("image/jpeg", QUALIDADE_JPEG),
                 FORMATO_IMAGEM,
@@ -179,6 +181,8 @@ export const useExportarPdf = () => {
               offsetPx += fatiaAlturaPx;
 
               if (offsetPx < alturaPx) {
+                // Ainda ha conteudo a desenhar: abre uma nova pagina para a
+                // proxima fatia.
                 doc.addPage();
                 cursorY = MARGEM_MM;
               } else {

--- a/src/pages/Gerenciar/ExtracaoDados/hooks/useExportarPdf.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/hooks/useExportarPdf.ts
@@ -1,0 +1,218 @@
+import { useCallback, useState } from "react";
+import type { RefObject } from "react";
+import html2canvas from "html2canvas";
+import { jsPDF } from "jspdf";
+
+// A4 em paisagem (landscape): largura e altura invertidas.
+const A4_LARGURA_MM = 297;
+const A4_ALTURA_MM = 210;
+const MARGEM_MM = 10;
+const CONTEUDO_LARGURA_MM = A4_LARGURA_MM - MARGEM_MM * 2;
+const CONTEUDO_ALTURA_MM = A4_ALTURA_MM - MARGEM_MM * 2;
+
+// JPEG reduz drasticamente o tamanho do PDF frente ao PNG (lossless), mantendo
+// legibilidade aceitavel para um relatorio. A escala 1.5 preserva nitidez de
+// impressao cortando ~44% dos pixels em relacao a 2.
+const FORMATO_IMAGEM = "JPEG";
+const QUALIDADE_JPEG = 0.8;
+const ESCALA_CAPTURA = 1.5;
+
+const aguardar = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Aguarda os graficos (@ant-design/charts) terminarem de desenhar no canvas.
+ * Eles renderizam de forma assincrona, entao esperamos ate que todos os
+ * `<canvas>` tenham dimensao valida ou um tempo limite ser atingido.
+ */
+const aguardarGraficosProntos = async (container: HTMLElement) => {
+  const tentativasMaximas = 30;
+
+  for (let tentativa = 0; tentativa < tentativasMaximas; tentativa += 1) {
+    const canvases = Array.from(container.querySelectorAll("canvas"));
+    const todosProntos =
+      canvases.length > 0 &&
+      canvases.every((canvas) => canvas.width > 0 && canvas.height > 0);
+
+    if (todosProntos) {
+      // Folego extra para a animacao das barras assentar antes da captura.
+      await aguardar(300);
+      return;
+    }
+
+    await aguardar(100);
+  }
+};
+
+type ResultadoCaptura = {
+  dataUrl: string;
+  larguraPx: number;
+  alturaPx: number;
+};
+
+/**
+ * Captura um elemento como imagem. Para os cards de grafico, le o `<canvas>`
+ * diretamente (toDataURL) porque o html2canvas frequentemente nao copia o
+ * conteudo de canvas de terceiros, deixando a area do grafico em branco.
+ */
+const capturarSecao = async (
+  elemento: HTMLElement
+): Promise<ResultadoCaptura> => {
+  const canvas = await html2canvas(elemento, {
+    scale: ESCALA_CAPTURA,
+    useCORS: true,
+    backgroundColor: "#ffffff",
+    logging: false,
+  });
+
+  return {
+    dataUrl: canvas.toDataURL("image/jpeg", QUALIDADE_JPEG),
+    larguraPx: canvas.width,
+    alturaPx: canvas.height,
+  };
+};
+
+export const useExportarPdf = () => {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportarPdf = useCallback(
+    async (containerRef: RefObject<HTMLElement | null>) => {
+      const container = containerRef.current;
+
+      if (!container || isExporting) {
+        return;
+      }
+
+      setIsExporting(true);
+
+      try {
+        await aguardarGraficosProntos(container);
+
+        const secoes = Array.from(
+          container.querySelectorAll<HTMLElement>("[data-pdf-section]")
+        );
+
+        if (secoes.length === 0) {
+          return;
+        }
+
+        const doc = new jsPDF({
+          orientation: "landscape",
+          unit: "mm",
+          format: "a4",
+        });
+
+        let cursorY = MARGEM_MM;
+
+        for (const secao of secoes) {
+          const { dataUrl, larguraPx, alturaPx } = await capturarSecao(secao);
+          const alturaMm = (alturaPx * CONTEUDO_LARGURA_MM) / larguraPx;
+
+          // Se a secao nao cabe no espaco restante da pagina, cria nova pagina.
+          if (
+            cursorY > MARGEM_MM &&
+            cursorY + alturaMm > A4_ALTURA_MM - MARGEM_MM
+          ) {
+            doc.addPage();
+            cursorY = MARGEM_MM;
+          }
+
+          // Secao mais alta que uma pagina inteira: fatia em paginas.
+          if (alturaMm > CONTEUDO_ALTURA_MM) {
+            const escala = CONTEUDO_LARGURA_MM / larguraPx;
+            const paginaAlturaPx = CONTEUDO_ALTURA_MM / escala;
+            let offsetPx = 0;
+
+            while (offsetPx < alturaPx) {
+              const fatiaAlturaPx = Math.min(
+                paginaAlturaPx,
+                alturaPx - offsetPx
+              );
+
+              const fatiaCanvas = document.createElement("canvas");
+              fatiaCanvas.width = larguraPx;
+              fatiaCanvas.height = fatiaAlturaPx;
+              const ctx = fatiaCanvas.getContext("2d");
+
+              if (ctx) {
+                // JPEG nao tem transparencia: areas vazias virariam preto.
+                // Preenchemos a fatia com branco antes de desenhar.
+                ctx.fillStyle = "#ffffff";
+                ctx.fillRect(0, 0, larguraPx, fatiaAlturaPx);
+
+                const img = new Image();
+                img.src = dataUrl;
+                await new Promise<void>((resolve) => {
+                  img.onload = () => resolve();
+                });
+                ctx.drawImage(
+                  img,
+                  0,
+                  offsetPx,
+                  larguraPx,
+                  fatiaAlturaPx,
+                  0,
+                  0,
+                  larguraPx,
+                  fatiaAlturaPx
+                );
+              }
+
+              const fatiaAlturaMm = fatiaAlturaPx * escala;
+
+              if (cursorY > MARGEM_MM) {
+                doc.addPage();
+                cursorY = MARGEM_MM;
+              }
+
+              doc.addImage(
+                fatiaCanvas.toDataURL("image/jpeg", QUALIDADE_JPEG),
+                FORMATO_IMAGEM,
+                MARGEM_MM,
+                cursorY,
+                CONTEUDO_LARGURA_MM,
+                fatiaAlturaMm,
+                undefined,
+                "FAST"
+              );
+
+              offsetPx += fatiaAlturaPx;
+
+              if (offsetPx < alturaPx) {
+                doc.addPage();
+                cursorY = MARGEM_MM;
+              } else {
+                cursorY += fatiaAlturaMm + 6;
+              }
+            }
+
+            continue;
+          }
+
+          doc.addImage(
+            dataUrl,
+            FORMATO_IMAGEM,
+            MARGEM_MM,
+            cursorY,
+            CONTEUDO_LARGURA_MM,
+            alturaMm,
+            undefined,
+            "FAST"
+          );
+
+          cursorY += alturaMm + 6;
+        }
+
+        const hoje = new Date().toISOString().slice(0, 10);
+        doc.save(`extracao-dados-${hoje}.pdf`);
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [isExporting]
+  );
+
+  return { exportarPdf, isExporting };
+};
+
+export default useExportarPdf;

--- a/src/pages/Gerenciar/ExtracaoDados/styles.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/styles.ts
@@ -118,6 +118,26 @@ export const RelatoriosDetalhadosTable = styled(StyledTable)`
   }
 ` as typeof StyledTable;
 
+export const PdfHeader = styled.div`
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #d9d9d9;
+
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #032b68;
+  }
+
+  span {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.875rem;
+    color: #595959;
+  }
+`;
+
 export const IndicatorCard = styled(Card)`
   height: 100%;
   border-radius: 0.5rem;

--- a/src/pages/Gerenciar/ExtracaoDados/testHelpers/testMocks.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/testHelpers/testMocks.tsx
@@ -45,14 +45,17 @@ export const createMockBaseTela = () => {
   return ({
     children,
     title,
+    buttons,
   }: {
     children: React.ReactNode;
     title: string;
+    buttons?: React.ReactNode;
   }) =>
     React.createElement(
       "div",
       null,
       React.createElement("h1", null, title),
+      buttons,
       children
     );
 };

--- a/src/pages/Gerenciar/ExtracaoDados/utils/mapIndicadores.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/utils/mapIndicadores.ts
@@ -18,6 +18,7 @@ export const INDICADORES_VAZIOS: IExtracaoDadosIndicadores = {
   naoConvocados: 0,
   reconvocacoes: 0,
   semEscolha: 0,
+  pendentesEscolha: 0,
   autorizacoes: 0,
 };
 
@@ -28,6 +29,25 @@ const isCandidatosAno = (
   value !== null &&
   "convocados" in value &&
   "nao-convocados" in value;
+
+/**
+ * Pendentes de escolha: convocados que ainda nao registraram nenhuma situacao
+ * de escolha (escolha, nao-escolha ou reconvocacao). Valores nulos sao tratados
+ * como 0 e o resultado nunca e negativo.
+ */
+const calcularPendentes = (
+  convocados: number | null,
+  escolhas: number | null,
+  semEscolha: number | null,
+  reconvocacoes: number | null
+): number =>
+  Math.max(
+    0,
+    (convocados ?? 0) -
+      (escolhas ?? 0) -
+      (semEscolha ?? 0) -
+      (reconvocacoes ?? 0)
+  );
 
 const obterIndicadoresHabilitados = (
   habilitados: IExtracaoDadosResponse["candidatos"]["habilitados"] | undefined
@@ -52,7 +72,11 @@ export const mapExtracaoDadosTodosToIndicadores = (
     return INDICADORES_VAZIOS;
   }
 
-  const { habilitados, convocados, "nao-convocados": naoConvocados } = data.candidatos;
+  const {
+    habilitados,
+    convocados,
+    "nao-convocados": naoConvocados,
+  } = data.candidatos;
   const { escolha, reconvocacao, "nao-escolha": semEscolha } = data.escolhas;
 
   return {
@@ -63,6 +87,12 @@ export const mapExtracaoDadosTodosToIndicadores = (
     naoConvocados: naoConvocados ?? 0,
     reconvocacoes: reconvocacao ?? 0,
     semEscolha: semEscolha ?? 0,
+    pendentesEscolha: calcularPendentes(
+      convocados,
+      escolha,
+      semEscolha,
+      reconvocacao
+    ),
     autorizacoes: data.concurso?.["autorizacoes-publicadas"] ?? 0,
   };
 };
@@ -81,16 +111,29 @@ export const mapExtracaoDadosToIndicadores = (
   const candidatosAno = data.candidatos[ano];
   const escolhasAno = data.escolhas[ano];
 
+  const convocados = isCandidatosAno(candidatosAno)
+    ? candidatosAno.convocados
+    : 0;
+  const escolhasRealizadas = escolhasAno?.escolha ?? 0;
+  const reconvocacoes = escolhasAno?.reconvocacao ?? 0;
+  const semEscolha = escolhasAno?.["nao-escolha"] ?? 0;
+
   return {
     modoComparativo: false,
     ...habilitadosBase,
-    convocados: isCandidatosAno(candidatosAno) ? candidatosAno.convocados : 0,
-    escolhasRealizadas: escolhasAno?.escolha ?? 0,
+    convocados,
+    escolhasRealizadas,
     naoConvocados: isCandidatosAno(candidatosAno)
       ? candidatosAno["nao-convocados"]
       : 0,
-    reconvocacoes: escolhasAno?.reconvocacao ?? 0,
-    semEscolha: escolhasAno?.["nao-escolha"] ?? 0,
+    reconvocacoes,
+    semEscolha,
+    pendentesEscolha: calcularPendentes(
+      convocados,
+      escolhasRealizadas,
+      semEscolha,
+      reconvocacoes
+    ),
     autorizacoes: obterAutorizacoesDoAno(data.concurso, ano, {
       permitirFallbackRaiz: true,
     }),

--- a/src/pages/Gerenciar/ExtracaoDados/utils/mapIndicadoresComparativo.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/utils/mapIndicadoresComparativo.ts
@@ -82,6 +82,23 @@ export const mapExtracaoDadosToIndicadoresComparativo = (
   const autorizacoesAntigo = obterAutorizacoesDoAno(data.concurso, anoAntigo);
   const autorizacoesRecente = obterAutorizacoesDoAno(data.concurso, anoRecente);
 
+  // Pendentes de escolha por ano: convocados que ainda nao registraram nenhuma
+  // situacao de escolha (escolha, nao-escolha ou reconvocacao). Nunca negativo.
+  const pendentesAntigo = Math.max(
+    0,
+    convocadosAntigo -
+      (escolhasAntigo?.escolha ?? 0) -
+      (escolhasAntigo?.["nao-escolha"] ?? 0) -
+      (escolhasAntigo?.reconvocacao ?? 0)
+  );
+  const pendentesRecente = Math.max(
+    0,
+    convocadosRecente -
+      (escolhasRecente?.escolha ?? 0) -
+      (escolhasRecente?.["nao-escolha"] ?? 0) -
+      (escolhasRecente?.reconvocacao ?? 0)
+  );
+
   return {
     modoComparativo: true,
     anoAntigo,
@@ -121,6 +138,7 @@ export const mapExtracaoDadosToIndicadoresComparativo = (
       escolhasAntigo?.["nao-escolha"] ?? 0,
       escolhasRecente?.["nao-escolha"] ?? 0
     ),
+    pendentesEscolha: montarItemComparativo(pendentesAntigo, pendentesRecente),
     autorizacoes: montarItemComparativo(autorizacoesAntigo, autorizacoesRecente),
   };
 };

--- a/src/pages/Gerenciar/ExtracaoDados/utils/mapRelatoriosDetalhados.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/utils/mapRelatoriosDetalhados.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import type {
+  IExtracaoDadosConcursoCargo,
   IExtracaoDadosResponse,
   IExtracaoDadosTodosResponse,
 } from "../../../../services/resources/relatorios/IExtracaoDados";
@@ -18,7 +19,12 @@ export type RelatorioDetalhadoItem = {
   dreOriginal: string;
   escolhas: number;
   naoEscolhas: number;
-  autorizacoes: number;
+};
+
+export type AutorizacaoPublicadaItem = {
+  key: string;
+  cargo: string;
+  quantidade: number;
   data_autorizacao: string;
 };
 
@@ -26,6 +32,16 @@ type ConcursoOption = {
   value: string;
   label: string;
 };
+
+export const mapCargosParaAutorizacoesPublicadas = (
+  cargos: IExtracaoDadosConcursoCargo[] | undefined
+): AutorizacaoPublicadaItem[] =>
+  (cargos ?? []).map((cargo) => ({
+    key: cargo.uuid,
+    cargo: cargo.nome,
+    quantidade: cargo.autorizacoes,
+    data_autorizacao: formatarDataAutorizacao(cargo.data_autorizacao),
+  }));
 
 export const mapDresConcursosParaRelatoriosDetalhados = (
   data: IExtracaoDadosTodosResponse | undefined,
@@ -39,32 +55,18 @@ export const mapDresConcursosParaRelatoriosDetalhados = (
 
   const concursosMap = new Map(concursosOptions.map((concurso) => [concurso.value, concurso.label]));
 
-  const dadosPorCargo = new Map(
-    (data?.concurso?.cargos ?? []).map((cargo) => [
-      cargo.codigo,
-      { autorizacoes: cargo.autorizacoes, data_autorizacao: cargo.data_autorizacao },
-    ])
-  );
-
   return Object.entries(dresConcursos).flatMap(([concursoUuid, itens]) =>
-    itens.map((item, index) => {
-      const cargoInfo =
-        item.codigo_cargo != null ? dadosPorCargo.get(item.codigo_cargo) : undefined;
-
-      return {
-        key: `${concursoUuid}-${item.codigo_cargo ?? index}-${item.nome}`,
-        concursoUuid,
-        concurso: concursosMap.get(concursoUuid) ?? concursoUuid,
-        cargo: item.cargo_descricao ?? "-",
-        codigoCargo: item.codigo_cargo,
-        dre: formatarNomeDreParaTabela(item.nome),
-        dreOriginal: item.nome,
-        escolhas: item.escolhas,
-        naoEscolhas: Math.max(item.vagas - item.escolhas, 0),
-        autorizacoes: cargoInfo?.autorizacoes ?? 0,
-        data_autorizacao: formatarDataAutorizacao(cargoInfo?.data_autorizacao),
-      };
-    })
+    itens.map((item, index) => ({
+      key: `${concursoUuid}-${item.codigo_cargo ?? index}-${item.nome}`,
+      concursoUuid,
+      concurso: concursosMap.get(concursoUuid) ?? concursoUuid,
+      cargo: item.cargo_descricao ?? "-",
+      codigoCargo: item.codigo_cargo,
+      dre: formatarNomeDreParaTabela(item.nome),
+      dreOriginal: item.nome,
+      escolhas: item.escolhas,
+      naoEscolhas: Math.max(item.vagas - item.escolhas, 0),
+    }))
   );
 };
 
@@ -84,29 +86,15 @@ export const mapDresParaRelatoriosDetalhados = (
   const concursosMap = new Map(concursosOptions.map((concurso) => [concurso.value, concurso.label]));
   const concurso = concursosMap.get(concursoUuid) ?? concursoUuid;
 
-  const dadosPorCargo = new Map(
-    (data?.concurso?.cargos ?? []).map((cargo) => [
-      cargo.codigo,
-      { autorizacoes: cargo.autorizacoes, data_autorizacao: cargo.data_autorizacao },
-    ])
-  );
-
-  return itens.map((item, index) => {
-    const cargoInfo =
-      item.codigo_cargo != null ? dadosPorCargo.get(item.codigo_cargo) : undefined;
-
-    return {
-      key: `${concursoUuid}-${item.codigo_cargo ?? index}-${item.nome}`,
-      concursoUuid,
-      concurso,
-      cargo: item.cargo_descricao ?? "-",
-      codigoCargo: item.codigo_cargo,
-      dre: formatarNomeDreParaTabela(item.nome),
-      dreOriginal: item.nome,
-      escolhas: item.escolhas,
-      naoEscolhas: Math.max(item.vagas - item.escolhas, 0),
-      autorizacoes: cargoInfo?.autorizacoes ?? 0,
-      data_autorizacao: formatarDataAutorizacao(cargoInfo?.data_autorizacao),
-    };
-  });
+  return itens.map((item, index) => ({
+    key: `${concursoUuid}-${item.codigo_cargo ?? index}-${item.nome}`,
+    concursoUuid,
+    concurso,
+    cargo: item.cargo_descricao ?? "-",
+    codigoCargo: item.codigo_cargo,
+    dre: formatarNomeDreParaTabela(item.nome),
+    dreOriginal: item.nome,
+    escolhas: item.escolhas,
+    naoEscolhas: Math.max(item.vagas - item.escolhas, 0),
+  }));
 };

--- a/src/pages/Gerenciar/ExtracaoDados/utils/mapRelatoriosDetalhados.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/utils/mapRelatoriosDetalhados.ts
@@ -183,6 +183,40 @@ export const mapCargosParaAutorizacoesPublicadas = (
     data_autorizacao: formatarDataAutorizacao(cargo.data_autorizacao),
   }));
 
+/**
+ * Monta as autorizacoes publicadas a partir do concurso filtrado, cujos cargos
+ * vivem aninhados nos blocos por ano (concurso[ano].cargos) e nao na raiz.
+ *
+ * Gera uma linha por cargo de cada ano selecionado, preservando todas as
+ * secoes de "autorizacoes-publicadas" presentes na resposta (um mesmo cargo
+ * que aparece em dois anos rende duas linhas, uma por ano). Quando nenhum bloco
+ * de ano possui cargos, cai para os cargos da raiz.
+ */
+export const mapConcursoFiltradoParaAutorizacoesPublicadas = (
+  concurso: IExtracaoDadosConcursoFiltrado | undefined,
+  anos: string[]
+): AutorizacaoPublicadaItem[] => {
+  const itens = anos.flatMap((ano) => {
+    const dadosAno = concurso?.[ano];
+    if (!isConcursoAno(dadosAno)) {
+      return [];
+    }
+
+    return (dadosAno.cargos ?? []).map((cargo) => ({
+      key: `${ano}-${cargo.uuid}`,
+      cargo: cargo.nome,
+      quantidade: Number(cargo.autorizacoes) || 0,
+      data_autorizacao: formatarDataAutorizacao(cargo.data_autorizacao),
+    }));
+  });
+
+  if (!itens.length) {
+    return mapCargosParaAutorizacoesPublicadas(concurso?.cargos);
+  }
+
+  return itens;
+};
+
 export const mapDresConcursosParaRelatoriosDetalhados = (
   data: IExtracaoDadosTodosResponse | undefined,
   concursosOptions: ConcursoOption[]

--- a/src/services/resources/relatorios/IExtracaoDados.ts
+++ b/src/services/resources/relatorios/IExtracaoDados.ts
@@ -146,6 +146,7 @@ export interface IExtracaoDadosIndicadores {
   naoConvocados: IndicadorValor;
   reconvocacoes: IndicadorValor;
   semEscolha: IndicadorValor;
+  pendentesEscolha: IndicadorValor;
   autorizacoes: IndicadorValor;
 }
 
@@ -175,5 +176,6 @@ export interface IExtracaoDadosIndicadoresComparativo {
   naoConvocados: IExtracaoDadosIndicadorComparativoItem;
   reconvocacoes: IExtracaoDadosIndicadorComparativoItem;
   semEscolha: IExtracaoDadosIndicadorComparativoItem;
+  pendentesEscolha: IExtracaoDadosIndicadorComparativoItem;
   autorizacoes: IExtracaoDadosIndicadorComparativoItem;
 }


### PR DESCRIPTION
## Descrição

Refina a tela de Extração de Dados e a geração do PDF, alinhando os
indicadores exibidos e garantindo que o PDF reflita o filtro aplicado.

## Alterações

### Indicadores
- **Novo indicador "Pendentes de escolha"** nos modos simples e
  comparativo, calculado como `convocados − escolhas − não-escolhas −
  reconvocações` (nunca negativo, nulos tratados como 0).
- **Remoção do card "Lista específica"**; o breakdown Geral/PCD/NNA passa
  a ser exibido dentro do card "Habilitados".

### Geração de PDF
- O PDF agora **reflete o filtro aplicado na tela**: exporta o
  comparativo de 2 anos quando selecionado, ou a versão simples (sem
  filtro ou 1 ano) — antes exportava sempre o consolidado.
- Removida a linha "Filtro aplicado" do cabeçalho do PDF.
- Correção: seções mais altas que uma página não deixam mais uma página
  em branco ao final.

### Autorizações Publicadas
- Quando há filtro, as autorizações são montadas a partir dos cargos
  aninhados por ano do concurso filtrado
  (`mapConcursoFiltradoParaAutorizacoesPublicadas`), com fallback para os
  cargos da raiz.

### Relatórios Detalhados
- Removidas as colunas "Não Escolhas", "Autorizações" e
  "Última atualização".


[AB#151022](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151022)
[AB#151023](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151023)
[AB#151024](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151024)
[AB#150060](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/150060)
[AB#149911](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149911)
