### PR TITLE
feat(152034): Adiciona campos de observação e quantidade em importação de habilitados

### DIFF
--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/components/RelatoriosDetalhados.test.tsx
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/components/RelatoriosDetalhados.test.tsx
@@ -15,6 +15,8 @@ const relatoriosMock: RelatorioDetalhadoItem[] = [
     dreOriginal: "Diretoria Regional de Educação Butantã",
     escolhas: 10,
     naoEscolhas: 5,
+    autorizacoes: 5,
+    data_autorizacao: "15/06/2025",
   },
   {
     key: "2",
@@ -26,6 +28,8 @@ const relatoriosMock: RelatorioDetalhadoItem[] = [
     dreOriginal: "Diretoria Regional de Educação Centro",
     escolhas: 8,
     naoEscolhas: 2,
+    autorizacoes: 3,
+    data_autorizacao: "20/07/2025",
   },
 ];
 
@@ -39,13 +43,6 @@ describe("RelatoriosDetalhados", () => {
     expect(screen.getByRole("cell", { name: "Coordenador" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /filtrar/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /limpar filtros/i })).toBeInTheDocument();
-  });
-
-  it("exibe data da última atualização", () => {
-    render(<RelatoriosDetalhados data={relatoriosMock} />);
-
-    expect(screen.getByText("15/06/2025")).toBeInTheDocument();
-    expect(screen.getByText("20/07/2025")).toBeInTheDocument();
   });
 
   it("mantém todos os registros ao limpar filtros", async () => {

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapGraficosDre.test.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapGraficosDre.test.ts
@@ -45,6 +45,7 @@ describe("mapGraficosDre", () => {
           escolhas: 50,
           vagas: 100,
           percentualPreenchimento: 50,
+          modoComparativo: false,
         },
         {
           key: "Centro",
@@ -52,6 +53,7 @@ describe("mapGraficosDre", () => {
           escolhas: 30,
           vagas: 80,
           percentualPreenchimento: 38,
+          modoComparativo: false,
         },
       ]);
     });
@@ -64,21 +66,22 @@ describe("mapGraficosDre", () => {
 
   describe("mapeamentos filtrados por ano", () => {
     it("mapeia gráficos e tabela a partir dos dados do ano", () => {
-      expect(mapDresParaGraficoEscolhas(extracaoDadosFiltradoMock, "2024")).toEqual([
+      expect(mapDresParaGraficoEscolhas(extracaoDadosFiltradoMock, ["2024"])).toEqual([
         { nome: "DRE Butantã", valor: 25 },
       ]);
 
-      expect(mapDresParaGraficoVagas(extracaoDadosFiltradoMock, "2024")).toEqual([
+      expect(mapDresParaGraficoVagas(extracaoDadosFiltradoMock, ["2024"])).toEqual([
         { nome: "DRE Butantã", valor: 40 },
       ]);
 
-      expect(mapDresParaTabela(extracaoDadosFiltradoMock, "2024")).toEqual([
+      expect(mapDresParaTabela(extracaoDadosFiltradoMock, ["2024"])).toEqual([
         {
           key: "Butantã",
           nome: "Butantã",
           escolhas: 25,
           vagas: 40,
           percentualPreenchimento: 63,
+          modoComparativo: false,
         },
       ]);
     });
@@ -96,7 +99,7 @@ describe("mapGraficosDre", () => {
         },
       };
 
-      expect(mapDresParaTabela(data, "2024")[0].percentualPreenchimento).toBe(0);
+      expect(mapDresParaTabela(data, ["2024"])[0].percentualPreenchimento).toBe(0);
     });
   });
 });

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapIndicadores.test.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapIndicadores.test.ts
@@ -45,7 +45,8 @@ describe("mapIndicadores", () => {
     });
 
     it("mapeia corretamente os indicadores filtrados por um ano", () => {
-      expect(mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, "2024")).toEqual({
+      expect(mapExtracaoDadosToIndicadores(extracaoDadosFiltradoMock, ["2024"])).toEqual({
+        modoComparativo: false,
         habilitados: 200,
         listaEspecifica: 200,
         listaGeral: 150,
@@ -56,6 +57,8 @@ describe("mapIndicadores", () => {
         naoConvocados: 120,
         reconvocacoes: 10,
         semEscolha: 20,
+        // pendentes = 80 - 60 - 20 - 10 = 0 (clampado)
+        pendentesEscolha: 0,
         autorizacoes: 8,
       });
     });

--- a/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapRelatoriosDetalhados.test.ts
+++ b/src/pages/Gerenciar/ExtracaoDados/__tests__/utils/mapRelatoriosDetalhados.test.ts
@@ -53,7 +53,7 @@ describe("mapRelatoriosDetalhados", () => {
   it("mapeia relatórios detalhados filtrados por concurso", () => {
     const resultado = mapDresParaRelatoriosDetalhados(
       extracaoDadosFiltradoMock,
-      "2024",
+      ["2024"],
       "uuid-concurso-1",
       concursosOptionsMock
     );
@@ -73,19 +73,21 @@ describe("mapRelatoriosDetalhados", () => {
     });
   });
 
-  it("não inclui campos de autorização nos itens de relatórios detalhados", () => {
+  it("inclui autorizações e data de autorização nos itens de relatórios detalhados", () => {
     const resultado = mapDresConcursosParaRelatoriosDetalhados(
       extracaoDadosTodosMock,
       concursosOptionsMock
     );
 
-    expect(resultado[0]).not.toHaveProperty("autorizacoes");
-    expect(resultado[0]).not.toHaveProperty("data_autorizacao");
+    expect(resultado[0]).toMatchObject({
+      autorizacoes: 5,
+      data_autorizacao: "15/06/2025 10:30",
+    });
   });
 
   it("retorna lista vazia quando não há dres_concursos para o concurso", () => {
     expect(
-      mapDresParaRelatoriosDetalhados(extracaoDadosFiltradoMock, "2024", "uuid-inexistente", [])
+      mapDresParaRelatoriosDetalhados(extracaoDadosFiltradoMock, ["2024"], "uuid-inexistente", [])
     ).toEqual([]);
   });
 });

--- a/src/pages/ImportacaoDados/Escolhas/components/UltimasImportacoesDeEscolhasTable.tsx
+++ b/src/pages/ImportacaoDados/Escolhas/components/UltimasImportacoesDeEscolhasTable.tsx
@@ -10,6 +10,7 @@ import { CustomTitle } from "../../Vagas/components/style";
 import { StyledTable } from "../../../../components/EstilosCompartilhados";
 import type { IImportacaoEscolhasResponse } from "../../../../services/resources/importacaoDados/IImportacaoArquivos";
 import ErroModal from "./ErroModal";
+import { formatarStatusImportacao } from "../../utils/statusImportacao";
 
 interface IImportacaoEscolhasResponseComNome extends IImportacaoEscolhasResponse {
   processo_nome?: string;
@@ -111,7 +112,7 @@ const UltimasImportacoesDeEscolhasTable: React.FC<UltimasImportacoesDeEscolhasTa
       dataIndex: "status",
       key: "status",
       align: "center",
-      render: (status: string) => status || "-",
+      render: (status: string) => formatarStatusImportacao(status),
     },
     {
       title: "Ações",

--- a/src/pages/ImportacaoDados/Habilitados/HabilitadosFormTab.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/HabilitadosFormTab.tsx
@@ -162,6 +162,7 @@ const HabilitadosFormTab: React.FC<HabilitadosProps> = ({
                       {...field}
                       disabled={!canImportarHabilitados}
                       rows={4}
+                      autoSize={{ minRows: 4, maxRows: 4 }}
                       maxLength={2000}
                       showCount
                       placeholder="Digite uma observação sobre esta importação (opcional)"

--- a/src/pages/ImportacaoDados/Habilitados/HabilitadosFormTab.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/HabilitadosFormTab.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Row, Col, Select, Button, Tooltip, Spin } from "antd";
+import { Row, Col, Select, Button, Tooltip, Spin, Input } from "antd";
 import { Controller } from "react-hook-form";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useImportacaoDados } from "./hooks/useImportacaoDadosHabilitados";
@@ -146,7 +146,31 @@ const HabilitadosFormTab: React.FC<HabilitadosProps> = ({
           </Col>
           </Row>
 
-        
+          <Row gutter={40}>
+            <Col xs={24}>
+              <Controller
+                control={control}
+                name="observacao"
+                render={({ field }) => (
+                  <CustomFormItem
+                    label="Observação"
+                    validateStatus={formErrors.observacao ? "error" : undefined}
+                    help={formErrors.observacao?.message}
+                    labelCol={{ span: 24 }}
+                  >
+                    <Input.TextArea
+                      {...field}
+                      disabled={!canImportarHabilitados}
+                      rows={4}
+                      maxLength={2000}
+                      showCount
+                      placeholder="Digite uma observação sobre esta importação (opcional)"
+                    />
+                  </CustomFormItem>
+                )}
+              />
+            </Col>
+          </Row>
 
       </TabContentContainer>
       <ActionButtonsContainer>

--- a/src/pages/ImportacaoDados/Habilitados/HistoricoHabilitadosTela.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/HistoricoHabilitadosTela.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Row, Col, Typography, Space, Tooltip } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import dayjs from "dayjs";
-import { WarningOutlined } from "@ant-design/icons";
+import { WarningOutlined, EyeOutlined } from "@ant-design/icons";
 import { Link, useNavigate } from "react-router-dom";
 
 import BaseTela, { type TitleItem } from "../../Base/BaseTela";
@@ -17,7 +17,9 @@ import {
 import { CustomTitle } from "../Vagas/components/style";
 import { useImportacaoDados } from "./hooks/useImportacaoDadosHabilitados";
 import ErroModal from "./components/ErroModal";
+import DetalhesHabilitadosModal from "./components/DetalhesHabilitadosModal";
 import { useGetDownloadError, TipoImportacao } from "../hooks/useGetDownloadError";
+import { formatarStatusImportacao } from "../utils/statusImportacao";
 
 const { Text } = Typography;
 
@@ -37,6 +39,7 @@ const HistoricoHabilitadosTela: React.FC = () => {
   } = useImportacaoDados();
 
   const [isErrosModalOpen, setIsErrosModalOpen] = useState(false);
+  const [isDetalhesModalOpen, setIsDetalhesModalOpen] = useState(false);
   const [selectedRecord, setSelectedRecord] = useState<any | null>(null);
   const [tablePagination, setTablePagination] = useState({
     current: 1,
@@ -55,6 +58,16 @@ const HistoricoHabilitadosTela: React.FC = () => {
     setSelectedRecord(null);
   };
 
+  const handleOpenDetalhesModal = (record: any) => {
+    setSelectedRecord(record);
+    setIsDetalhesModalOpen(true);
+  };
+
+  const handleCloseDetalhesModal = () => {
+    setIsDetalhesModalOpen(false);
+    setSelectedRecord(null);
+  };
+
   const handleDownloadClick = () => {
     if (selectedRecord?.uuid) {
       handleDownload(selectedRecord.uuid);
@@ -65,11 +78,12 @@ const HistoricoHabilitadosTela: React.FC = () => {
 
   const columns: ColumnsType<any> = [
     {
-      title: "Data",
+      title: "Data e Hora",
       dataIndex: "criado_em",
       key: "criado_em",
       align: "center",
-      render: (text: string) => (text ? dayjs(text).format("DD/MM/YYYY") : "-"),
+      render: (text: string) =>
+        text ? dayjs(text).format("DD/MM/YYYY HH:mm") : "-",
     },
     {
       title: "Concurso",
@@ -86,11 +100,18 @@ const HistoricoHabilitadosTela: React.FC = () => {
       render: (text: string) => text || "-",
     },
     {
+      title: "Quantidade",
+      dataIndex: "quantidade",
+      key: "quantidade",
+      align: "center",
+      render: (quantidade: number | null) => quantidade ?? "-",
+    },
+    {
       title: "Status",
       dataIndex: "status",
       key: "status",
       align: "center",
-      render: (status: string) => status || "-",
+      render: (status: string) => formatarStatusImportacao(status),
     },
     {
       width: "12%",
@@ -99,7 +120,15 @@ const HistoricoHabilitadosTela: React.FC = () => {
       key: "x",
       align: "center",
       render: (_, record) => (
-        <Space size="small">
+        <Space size="middle">
+          {record.status !== "ERRO" && (
+            <Tooltip title="Ver detalhes da importação">
+              <EyeOutlined
+                style={{ cursor: "pointer", fontSize: "18px", color: "#032B68" }}
+                onClick={() => handleOpenDetalhesModal(record)}
+              />
+            </Tooltip>
+          )}
           {record.status === "ERRO" && (
             <Tooltip title="Importação com erro, clique para visualizar">
               <WarningOutlined
@@ -180,6 +209,12 @@ const HistoricoHabilitadosTela: React.FC = () => {
           importacaoErro={importacaoErro}
           onDownload={handleDownloadClick}
           isDownloading={isDownloading}
+        />
+
+        <DetalhesHabilitadosModal
+          open={isDetalhesModalOpen}
+          onClose={handleCloseDetalhesModal}
+          record={selectedRecord}
         />
       </TabContentContainer>
     </BaseTela>

--- a/src/pages/ImportacaoDados/Habilitados/components/DetalhesHabilitadosModal.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/components/DetalhesHabilitadosModal.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Modal, Descriptions, Button, Typography } from "antd";
+import dayjs from "dayjs";
+import { ButtonsContainer } from "../../Vagas/components/style";
+import type { IUltimasImportacoesHabilitados } from "../../../../services/resources/importacaoDados/IImportacaoArquivos";
+import { formatarStatusImportacao } from "../../utils/statusImportacao";
+
+interface DetalhesHabilitadosModalProps {
+  open: boolean;
+  onClose: () => void;
+  record: IUltimasImportacoesHabilitados | null;
+}
+
+const DetalhesHabilitadosModal: React.FC<DetalhesHabilitadosModalProps> = ({
+  open,
+  onClose,
+  record,
+}) => {
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width={"43.75rem"}
+      centered
+      title={
+        <Typography.Text strong style={{ fontSize: 16 }}>
+          Detalhes da Importação
+        </Typography.Text>
+      }
+    >
+      <Descriptions
+        bordered
+        column={1}
+        size="small"
+        labelStyle={{ fontWeight: 600, width: "30%" }}
+      >
+        <Descriptions.Item label="Concurso">
+          {record?.concurso_nome || "-"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Arquivo">
+          {record?.nome_arquivo || "-"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Data e Hora">
+          {record?.criado_em
+            ? dayjs(record.criado_em).format("DD/MM/YYYY HH:mm")
+            : "-"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Status">
+          {formatarStatusImportacao(record?.status)}
+        </Descriptions.Item>
+        <Descriptions.Item label="Quantidade">
+          {record?.quantidade ?? "-"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Observação">
+          <span style={{ whiteSpace: "pre-wrap" }}>
+            {record?.observacao || "-"}
+          </span>
+        </Descriptions.Item>
+      </Descriptions>
+
+      <ButtonsContainer>
+        <Button onClick={onClose}>Fechar</Button>
+      </ButtonsContainer>
+    </Modal>
+  );
+};
+
+export default DetalhesHabilitadosModal;

--- a/src/pages/ImportacaoDados/Habilitados/hooks/types.ts
+++ b/src/pages/ImportacaoDados/Habilitados/hooks/types.ts
@@ -1,6 +1,7 @@
 export interface IImportacaoHabilitadosFiltros {
   concurso: string | undefined;
   arquivo: File | null;
+  observacao?: string;
 }
 
 export interface IUltimaImportacaoHabilitados {
@@ -13,4 +14,5 @@ export interface IImportacaoHabilitadosPayload {
   concurso_uuid: string;
   arquivo: File;
   tipo: string;
+  observacao?: string;
 }

--- a/src/pages/ImportacaoDados/Habilitados/hooks/useImportacaoDadosHabilitados.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/hooks/useImportacaoDadosHabilitados.tsx
@@ -23,6 +23,7 @@ export const useImportacaoDados = () => {
     concurso: undefined,
     arquivo: null,
     tipo: "HABILITADOS",
+    observacao: "",
   };
 
   const {
@@ -72,6 +73,7 @@ export const useImportacaoDados = () => {
       concurso_uuid: concursoSelecionado.value,
       arquivo: data.arquivo!,
       tipo: "HABILITADOS",
+      observacao: data.observacao?.trim() || undefined,
     };
 
     try {

--- a/src/pages/ImportacaoDados/Habilitados/hooks/useImportacaoSchema.tsx
+++ b/src/pages/ImportacaoDados/Habilitados/hooks/useImportacaoSchema.tsx
@@ -13,6 +13,8 @@ const useImportacaoSchema = () => {
         if (!value) return false;
         return value.type === "text/csv" || value.name.endsWith(".csv");
       }),
+
+    observacao: yup.string().optional(),
   });
 };
 

--- a/src/pages/ImportacaoDados/Lotes/HistoricoLotesTela.tsx
+++ b/src/pages/ImportacaoDados/Lotes/HistoricoLotesTela.tsx
@@ -18,6 +18,7 @@ import { useImportacaoDadosLotes } from "./hooks/useImportacaoDadosLotes";
 import ErroLotesModal from "./components/ErroLotesModal";
 import DetalhesLotesModal from "./components/DetalhesLotesModal";
 import type { IImportacaoLotesResponse, IDetalheLoteAtualizado } from "./hooks/types";
+import { formatarStatusImportacao } from "../utils/statusImportacao";
 
 const { Text } = Typography;
 
@@ -94,7 +95,7 @@ const HistoricoLotesTela: React.FC = () => {
       key: "status",
       align: "center",
       render: (status: string) => (
-        <Tag color={statusColor[status] || "default"}>{status || "-"}</Tag>
+        <Tag color={statusColor[status] || "default"}>{formatarStatusImportacao(status)}</Tag>
       ),
     },
     {

--- a/src/pages/ImportacaoDados/Vagas/components/UltimasImportacoesDeVagasTable.tsx
+++ b/src/pages/ImportacaoDados/Vagas/components/UltimasImportacoesDeVagasTable.tsx
@@ -9,6 +9,7 @@ import { StyledTable } from "../../../../components/EstilosCompartilhados";
 import type { IUltimasImportacoesVagas } from "../../../../services/resources/importacaoDados/IImportacaoArquivos";
 import ErroModal from "./ErroModal";
 import { useGetDownloadError, TipoImportacao } from "../../hooks/useGetDownloadError";
+import { formatarStatusImportacao } from "../../utils/statusImportacao";
 
 interface UltimasImportacoesDeVagasTableProps extends TableProps<IUltimasImportacoesVagas> {
   data: IUltimasImportacoesVagas[];
@@ -65,7 +66,7 @@ const UltimasImportacoesDeVagasTable: React.FC<UltimasImportacoesDeVagasTablePro
       dataIndex: "status",
       key: "status",
       align: "center",
-      render: (status: string) => status || "-",
+      render: (status: string) => formatarStatusImportacao(status),
     },
     {
       title: "Ações",

--- a/src/pages/ImportacaoDados/utils/statusImportacao.ts
+++ b/src/pages/ImportacaoDados/utils/statusImportacao.ts
@@ -1,0 +1,18 @@
+/**
+ * Mapeamento das chaves de status de importação de arquivo para seus
+ * rótulos legíveis (espelha CHOICES_STATUS_IMPORTACAO_ARQUIVO do backend).
+ */
+export const STATUS_IMPORTACAO_LABEL: Record<string, string> = {
+  PENDENTE: "Pendente",
+  PROCESSANDO: "Processando",
+  CONCLUIDO: "Concluído",
+  ERRO: "Erro",
+};
+
+/**
+ * Retorna o rótulo legível de um status de importação. Se a chave for
+ * desconhecida, devolve o próprio valor; se vazio, devolve "-".
+ */
+export const formatarStatusImportacao = (
+  status?: string | null,
+): string => (status ? STATUS_IMPORTACAO_LABEL[status] ?? status : "-");

--- a/src/pages/ImportacaoDados/utils/statusImportacao.ts
+++ b/src/pages/ImportacaoDados/utils/statusImportacao.ts
@@ -1,7 +1,3 @@
-/**
- * Mapeamento das chaves de status de importação de arquivo para seus
- * rótulos legíveis (espelha CHOICES_STATUS_IMPORTACAO_ARQUIVO do backend).
- */
 export const STATUS_IMPORTACAO_LABEL: Record<string, string> = {
   PENDENTE: "Pendente",
   PROCESSANDO: "Processando",
@@ -9,10 +5,6 @@ export const STATUS_IMPORTACAO_LABEL: Record<string, string> = {
   ERRO: "Erro",
 };
 
-/**
- * Retorna o rótulo legível de um status de importação. Se a chave for
- * desconhecida, devolve o próprio valor; se vazio, devolve "-".
- */
 export const formatarStatusImportacao = (
   status?: string | null,
 ): string => (status ? STATUS_IMPORTACAO_LABEL[status] ?? status : "-");

--- a/src/pages/Relatorios/tests/PersonalizacaoModal.test.tsx
+++ b/src/pages/Relatorios/tests/PersonalizacaoModal.test.tsx
@@ -197,12 +197,9 @@ describe('PersonalizacaoModal', () => {
         expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked()
       );
 
-      // Fecha o modal: o efeito de reset limpa o estado interno e o hasFetchedRef.
       rerender(<PersonalizacaoModal {...defaultProps} open={false} />);
 
-      // Ao reabrir, o estado deve ter voltado ao padrão (logotipo marcado).
-      // O modal fechado congela o DOM da AntD, entao verificamos o reset pela
-      // reabertura em vez de inspecionar o checkbox do modal ja fechado.
+  
       mockGetPersonalizacaoRelatorio.mockResolvedValue(createMockData());
       rerender(<PersonalizacaoModal {...defaultProps} open />);
 

--- a/src/pages/Relatorios/tests/PersonalizacaoModal.test.tsx
+++ b/src/pages/Relatorios/tests/PersonalizacaoModal.test.tsx
@@ -190,16 +190,25 @@ describe('PersonalizacaoModal', () => {
 
   describe('Reset quando modal fecha', () => {
     it('deve resetar estados quando open muda para false', async () => {
+      // Carrega com usar_logotipo=false (checkbox desmarcado)
       mockGetPersonalizacaoRelatorio.mockResolvedValue(createMockData({ usar_logotipo: false }));
       const { rerender } = setupComponent();
-      await waitFor(() => expect(mockGetPersonalizacaoRelatorio).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked()
+      );
+
+      // Fecha o modal: o efeito de reset limpa o estado interno e o hasFetchedRef.
       rerender(<PersonalizacaoModal {...defaultProps} open={false} />);
-      await waitFor(() => {
-        const checkboxes = screen.queryAllByRole('checkbox');
-        if (checkboxes.length > 0) {
-          expect(checkboxes[0]).toBeChecked();
-        }
-      });
+
+      // Ao reabrir, o estado deve ter voltado ao padrão (logotipo marcado).
+      // O modal fechado congela o DOM da AntD, entao verificamos o reset pela
+      // reabertura em vez de inspecionar o checkbox do modal ja fechado.
+      mockGetPersonalizacaoRelatorio.mockResolvedValue(createMockData());
+      rerender(<PersonalizacaoModal {...defaultProps} open />);
+
+      await waitFor(() =>
+        expect(screen.getAllByRole('checkbox')[0]).toBeChecked()
+      );
     });
   });
 

--- a/src/services/resources/importacaoDados/IImportacaoArquivos.ts
+++ b/src/services/resources/importacaoDados/IImportacaoArquivos.ts
@@ -25,6 +25,17 @@ export interface IUltimasImportacoesVagas {
   erros?: IErroImportacao[] | null;
 }
 
+export interface IUltimasImportacoesHabilitados {
+  uuid: string;
+  nome_arquivo: string;
+  concurso_nome: string | null;
+  criado_em: string;
+  status: string;
+  quantidade: number | null;
+  observacao: string | null;
+  erros?: IErroImportacao[] | null;
+}
+
 
 export interface IGetLayout {    
       atualizado_em: string,

--- a/src/services/resources/importacaoDados/index.ts
+++ b/src/services/resources/importacaoDados/index.ts
@@ -1,9 +1,10 @@
 import type { AxiosRequestConfig } from "axios";
 import { appAxiosImportaArquivos } from "../../axios";
-import type { 
+import type {
   IGetLayout,
   IImportacaoFundacao,
   IUltimasImportacoesVagas,
+  IUltimasImportacoesHabilitados,
   IErroImportacaoResposta,
   IImportacaoEscolhasPayload,
   IImportacaoEscolhasResponse,
@@ -59,7 +60,7 @@ export const postImportacaoArquivosVagas = (
 
 // TODO adicionar JWT no header Authorization
 export const postImportacaoArquivosHabilitados = (
-  payload: { cargo?: string; arquivo: File; tipo: string, concurso_uuid:string, concurso_nome: string },
+  payload: { cargo?: string; arquivo: File; tipo: string, concurso_uuid:string, concurso_nome: string, observacao?: string },
   axiosRequestConfig?: AxiosRequestConfig
 ) => {
   const { signal, abort } = new AbortController();
@@ -70,6 +71,7 @@ export const postImportacaoArquivosHabilitados = (
   formData.append('arquivo', payload.arquivo);
   formData.append('concurso_uuid', payload.concurso_uuid);
   formData.append('concurso_nome', payload.concurso_nome);
+  if (payload.observacao) formData.append('observacao', payload.observacao);
 
   const response = appAxiosImportaArquivos
     .post<IImportacaoFundacao>(URL.postImportacaoArquivosHabilitados(), formData, {
@@ -88,12 +90,12 @@ export const postImportacaoArquivosHabilitados = (
 };
 
 // // TODO adicionar JWT no header Authorization
-export const getImportacaoArquivosHabilitados = ( 
+export const getImportacaoArquivosHabilitados = (
   axiosRequestConfig?: AxiosRequestConfig
 ) => {
   const { signal, abort } = new AbortController();
   const response = appAxiosImportaArquivos
-    .get<PaginatedResponse<IImportacaoFundacao>>(URL.getImportacaoArquivosHabilitados(), {      
+    .get<IUltimasImportacoesHabilitados[]>(URL.getImportacaoArquivosHabilitados(), {
       paramsSerializer: queryParamsSerializer,
       signal,
       ...axiosRequestConfig,


### PR DESCRIPTION
## Descrição

Implementa os campos **Observação** e **Quantidade** na importação de
Habilitados e adiciona o **modal de detalhes da importação**. Inclui também
uma padronização de exibição do status entre as telas de importação.

## O que muda

### Habilitados
- **Formulário:** novo campo **Observação** (textarea livre, opcional, com
  contador de caracteres), enviado no POST da importação.
- **Histórico:**
  - Coluna **"Data" → "Data e Hora"** (`DD/MM/YYYY HH:mm`).
  - Nova coluna **Quantidade** (nº de registros do arquivo importado).
  - Novo ícone de **detalhes (olho)**, sempre visível, que abre o modal.
    O ícone de erro (⚠️) continua aparecendo apenas em importações com erro.
- **Modal de detalhes** (`DetalhesHabilitadosModal`): resumo completo da
  importação — Concurso, Arquivo, Data e Hora, Status, Quantidade e Observação.

### Serviços e tipos
- `postImportacaoArquivosHabilitados` passa a enviar `observacao`.
- Nova interface `IUltimasImportacoesHabilitados` e tipagem correta da
  listagem (antes tipada como `IImportacaoFundacao`).

### Padronização de status (Escolhas, Lotes, Vagas, Habilitados)
- Novo helper `utils/statusImportacao.formatarStatusImportacao`, que espelha
  o `CHOICES_STATUS_IMPORTACAO_ARQUIVO` do backend e exibe rótulos legíveis
  (`CONCLUIDO` → "Concluído"). Aplicado nas tabelas de histórico das quatro
  telas de importação.

[AB#152034](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/152034)
[AB#151958](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151958)
