### PR TITLE
feat(152030): Refatoração e ajustes de validação na criação e edição de agendas

### DIFF
--- a/src/pages/CriarEditarConvocacao/Agenda/AgendaTela.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/AgendaTela.tsx
@@ -70,6 +70,7 @@ const AgendaTela: React.FC = () => {
     saveEdit,
     calcularIntervaloClassificacao,
     verificarConflitoTempoReal,
+    validarRedistribuicaoClassificacao,
     cargoParaExpandir,
     limparExpansao,
     salvarAgendasNoBackend,
@@ -88,18 +89,6 @@ const AgendaTela: React.FC = () => {
         <Text
           strong
           style={inlineStyles.breadcrumbItem}
-          onClick={() => navigate("/")}
-        >
-          Home
-        </Text>
-      ),
-    },
-    {
-      title: (
-        <Text
-          strong
-          style={inlineStyles.breadcrumbItem}
-          onClick={() => navigate("/processos")}
         >
           Processos
         </Text>
@@ -146,7 +135,7 @@ const AgendaTela: React.FC = () => {
   };
 
   const prev = () => {
-    navigate(`/processos/convocacao/editar/${uuid}/selecao-cargos`)    
+    navigate(`/processos/convocacao/editar/${uuid}/selecao-cargos`)
   };
 
   const formatDate = (value?: string) => {
@@ -335,6 +324,7 @@ const AgendaTela: React.FC = () => {
               saveEdit={saveEdit}
               calcularIntervaloClassificacao={calcularIntervaloClassificacao}
               verificarConflitoTempoReal={verificarConflitoTempoReal}
+              validarRedistribuicaoClassificacao={validarRedistribuicaoClassificacao}
               cargoParaExpandir={cargoParaExpandir}
               limparExpansao={limparExpansao}
             />

--- a/src/pages/CriarEditarConvocacao/Agenda/__tests__/Agenda.test.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/__tests__/Agenda.test.tsx
@@ -103,6 +103,8 @@ const mockAgendaAberto = {
   cargo_codigo: 'P001',
 };
 
+const mockValidarRedistribuicaoClassificacao = jest.fn(() => ({ valid: true }));
+
 jest.mock('../hooks/useAgenda', () => ({
   useAgenda: jest.fn(() => ({
     processoConvocacaoData: mockProcessoConvocacaoData,
@@ -129,6 +131,7 @@ jest.mock('../hooks/useAgenda', () => ({
     saveEdit: mockSaveEdit,
     calcularIntervaloClassificacao: mockCalcularIntervaloClassificacao,
     verificarConflitoTempoReal: mockVerificarConflitoTempoReal,
+    validarRedistribuicaoClassificacao: mockValidarRedistribuicaoClassificacao,
     cargoParaExpandir: null,
     limparExpansao: mockLimparExpansao,
     salvarAgendasNoBackend: mockSalvarAgendasNoBackend,
@@ -300,8 +303,8 @@ describe('AgendaTela', () => {
       
       const breadcrumb = screen.getByTestId('breadcrumb');
       expect(breadcrumb).toBeInTheDocument();
-      expect(breadcrumb).toHaveAttribute('data-count', '4');
-      expect(screen.getByTestId('breadcrumb-item-3')).toHaveTextContent('Nova Convocação');
+      expect(breadcrumb).toHaveAttribute('data-count', '3');
+      expect(screen.getByTestId('breadcrumb-item-2')).toHaveTextContent('Nova Convocação');
     });
 
     it('deve renderizar o Steps com step atual 2', () => {
@@ -551,24 +554,6 @@ describe('AgendaTela', () => {
   });
 
   describe('Navegação e breadcrumbs', () => {
-    it('deve navegar para Home ao clicar no breadcrumb Home', () => {
-      renderWithProviders(<AgendaTela />);
-      
-      const homeLink = screen.getByText('Home');
-      fireEvent.click(homeLink);
-      
-      expect(mockNavigate).toHaveBeenCalledWith('/');
-    });
-
-    it('deve navegar para Processos ao clicar no breadcrumb Processos', () => {
-      renderWithProviders(<AgendaTela />);
-      
-      const processosLink = screen.getByText('Processos');
-      fireEvent.click(processosLink);
-      
-      expect(mockNavigate).toHaveBeenCalledWith('/processos');
-    });
-
     it('deve navegar para Convocação ao clicar no breadcrumb Convocação de candidatos', () => {
       renderWithProviders(<AgendaTela />);
       

--- a/src/pages/CriarEditarConvocacao/Agenda/__tests__/AgendaTabela.test.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/__tests__/AgendaTabela.test.tsx
@@ -1,0 +1,223 @@
+const mockFormValues: Record<string, { horaInicio: string; horaFim: string; classificacao: number }> = {
+  '1': { horaInicio: '10:00', horaFim: '11:00', classificacao: 30 },
+  '2': { horaInicio: '11:00', horaFim: '12:00', classificacao: 10 },
+};
+
+jest.mock('react-hook-form', () => ({
+  useForm: () => ({
+    control: {},
+    getValues: jest.fn((path?: string) => {
+      if (!path) return mockFormValues;
+      const [formKey, field] = path.split('.');
+      return mockFormValues[formKey]?.[field as keyof (typeof mockFormValues)[string]];
+    }),
+    reset: jest.fn(),
+    watch: jest.fn(() => mockFormValues),
+  }),
+  Controller: ({ render, defaultValue, name }: any) =>
+    render({
+      field: {
+        value: defaultValue ?? mockFormValues[name.split('.')[0]]?.[name.split('.')[1]],
+        onChange: jest.fn(),
+      },
+    }),
+}));
+
+jest.mock('antd', () => ({
+  ...jest.requireActual('antd'),
+  message: {
+    error: jest.fn(),
+  },
+}));
+
+import '../testHelpers/useAgendaMocks';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { message } from 'antd';
+import AgendaTabela from '../components/AgendaTabela';
+import { renderWithProviders } from '../../../../test-utils';
+import {
+  MENSAGEM_LIMITE_REDISTRIBUICAO,
+  type PeriodoItem,
+} from '../hooks/useAgenda';
+
+const mockCargos = [
+  {
+    uuid: 'cargo-uuid-1',
+    nome: 'Professor',
+    vagas: 10,
+    totalCandidatos: 40,
+  },
+];
+
+const criarPeriodo = (overrides: Partial<PeriodoItem> = {}): PeriodoItem => ({
+  id: 1,
+  cargo: 'Professor',
+  cargoUuid: 'cargo-uuid-1',
+  classificacao: 30,
+  dataEscolha: '15/01/2024',
+  sessao: 'Sessão 1',
+  horario: '10:00 às 11:00',
+  horaInicio: '10:00',
+  horaFim: '11:00',
+  isRetardatario: false,
+  tipoEscolha: 'PRESENCIAL',
+  modalidade: 'PRESENCIAL',
+  ...overrides,
+});
+
+const mockPeriodos: PeriodoItem[] = [
+  criarPeriodo({ id: 1 }),
+  criarPeriodo({
+    id: 2,
+    classificacao: 10,
+    sessao: 'Sessão 2',
+    horario: '11:00 às 12:00',
+    horaInicio: '11:00',
+    horaFim: '12:00',
+  }),
+];
+
+const criarProps = (overrides: Record<string, unknown> = {}) => ({
+  cargosAdicionados: mockCargos,
+  periodosList: mockPeriodos,
+  handleAgendarClick: jest.fn(),
+  handleRemoverPeriodo: jest.fn(),
+  editingKey: null,
+  isEditing: () => false,
+  edit: jest.fn(),
+  cancelEdit: jest.fn(),
+  saveEdit: jest.fn(() => ({ success: true })),
+  calcularIntervaloClassificacao: jest.fn(() => '1ª até 30ª'),
+  verificarConflitoTempoReal: jest.fn(() => false),
+  validarRedistribuicaoClassificacao: jest.fn(() => ({ valid: true })),
+  cargoParaExpandir: 'Professor',
+  limparExpansao: jest.fn(),
+  ...overrides,
+});
+
+describe('AgendaTabela - CriarEditarConvocacao', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFormValues['1'] = { horaInicio: '10:00', horaFim: '11:00', classificacao: 30 };
+    mockFormValues['2'] = { horaInicio: '11:00', horaFim: '12:00', classificacao: 10 };
+  });
+
+  it('deve renderizar cargos e expandir agendamentos do cargo', async () => {
+    renderWithProviders(<AgendaTabela {...criarProps()} />);
+
+    expect(screen.getByText('Professor')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Agendamentos')).toBeInTheDocument();
+    });
+  });
+
+  it('deve exibir erro inline quando redistribuição ultrapassa 30 nas outras agendas', async () => {
+    const validarRedistribuicaoClassificacao = jest.fn(() => ({
+      valid: false,
+      message: MENSAGEM_LIMITE_REDISTRIBUICAO,
+    }));
+
+    renderWithProviders(
+      <AgendaTabela
+        {...criarProps({
+          editingKey: 1,
+          isEditing: (record: PeriodoItem) => record.id === 1,
+          validarRedistribuicaoClassificacao,
+        })}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(MENSAGEM_LIMITE_REDISTRIBUICAO)).toBeInTheDocument();
+    });
+
+    expect(validarRedistribuicaoClassificacao).toHaveBeenCalled();
+  });
+
+  it('deve exibir erro inline quando intervalo de horário não é de 1 hora', async () => {
+    mockFormValues['1'] = { horaInicio: '10:00', horaFim: '12:00', classificacao: 30 };
+
+    renderWithProviders(
+      <AgendaTabela
+        {...criarProps({
+          periodosList: [
+            criarPeriodo({
+              id: 1,
+              horaInicio: '10:00',
+              horaFim: '12:00',
+              horario: '10:00 às 12:00',
+            }),
+          ],
+          editingKey: 1,
+          isEditing: (record: PeriodoItem) => record.id === 1,
+        })}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Intervalo permitido: somente 1h.')).toBeInTheDocument();
+    });
+  });
+
+  it('não deve exibir toast global para erro de redistribuição ao salvar', async () => {
+    const saveEdit = jest.fn(() => ({
+      success: false,
+      message: MENSAGEM_LIMITE_REDISTRIBUICAO,
+    }));
+
+    renderWithProviders(
+      <AgendaTabela
+        {...criarProps({
+          editingKey: 1,
+          isEditing: (record: PeriodoItem) => record.id === 1,
+          saveEdit,
+        })}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('check')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('check'));
+
+    expect(saveEdit).toHaveBeenCalled();
+    expect(message.error).not.toHaveBeenCalled();
+  });
+
+  it('não deve exibir toast global para erro de intervalo de horário ao salvar', async () => {
+    mockFormValues['1'] = { horaInicio: '10:00', horaFim: '12:00', classificacao: 30 };
+
+    const saveEdit = jest.fn(() => ({
+      success: false,
+      message: 'Intervalo permitido: somente 1h.',
+    }));
+
+    renderWithProviders(
+      <AgendaTabela
+        {...criarProps({
+          periodosList: [
+            criarPeriodo({
+              id: 1,
+              horaInicio: '10:00',
+              horaFim: '12:00',
+              horario: '10:00 às 12:00',
+            }),
+          ],
+          editingKey: 1,
+          isEditing: (record: PeriodoItem) => record.id === 1,
+          saveEdit,
+        })}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('check')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('check'));
+
+    expect(saveEdit).toHaveBeenCalled();
+    expect(message.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/CriarEditarConvocacao/Agenda/__tests__/useAgendaRedistribuicao.test.ts
+++ b/src/pages/CriarEditarConvocacao/Agenda/__tests__/useAgendaRedistribuicao.test.ts
@@ -1,0 +1,107 @@
+import '../testHelpers/useAgendaMocks';
+import {
+  MENSAGEM_LIMITE_REDISTRIBUICAO,
+  MAX_CANDIDATOS_POR_AGENDA,
+  ordenarSessoesPresenciais,
+  simularRedistribuicaoClassificacao,
+  type PeriodoItem,
+} from '../hooks/useAgenda';
+
+const criarPeriodo = (overrides: Partial<PeriodoItem> = {}): PeriodoItem => ({
+  id: 1,
+  cargo: 'Professor',
+  classificacao: 10,
+  dataEscolha: '15/01/2024',
+  sessao: 'Sessão 1',
+  horario: '10:00 às 11:00',
+  tipoEscolha: 'PRESENCIAL',
+  isRetardatario: false,
+  ...overrides,
+});
+
+describe('ordenarSessoesPresenciais', () => {
+  it('deve ordenar sessões presenciais por data e horário', () => {
+    const periodos = [
+      criarPeriodo({ id: 2, dataEscolha: '16/01/2024', horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 1, dataEscolha: '15/01/2024', horario: '11:00 às 12:00' }),
+      criarPeriodo({ id: 3, dataEscolha: '15/01/2024', horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 4, cargo: 'Professor', tipoEscolha: 'ONLINE', horario: 'Online' }),
+      criarPeriodo({ id: 5, isRetardatario: true, horario: '12:00 às 13:00' }),
+    ];
+
+    const ordenados = ordenarSessoesPresenciais(periodos, 'Professor');
+
+    expect(ordenados.map((periodo) => periodo.id)).toEqual([3, 1, 2]);
+  });
+});
+
+describe('simularRedistribuicaoClassificacao', () => {
+  it('deve permitir redistribuição quando agendas seguintes absorvem o excedente', () => {
+    const sessoes = [
+      criarPeriodo({ id: 1, classificacao: 19, horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 2, classificacao: 1, horario: '11:00 às 12:00' }),
+    ];
+
+    const resultado = simularRedistribuicaoClassificacao(sessoes, 0, 6);
+
+    expect(resultado).toEqual({ valid: true, carryRestante: 0 });
+  });
+
+  it('deve impedir redistribuição quando agendas seguintes ultrapassariam 30 candidatos', () => {
+    const sessoes = [
+      criarPeriodo({ id: 1, classificacao: 30, horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 2, classificacao: 10, horario: '11:00 às 12:00' }),
+    ];
+
+    const resultado = simularRedistribuicaoClassificacao(sessoes, 0, 5);
+
+    expect(resultado.valid).toBe(false);
+    expect(resultado.carryRestante).toBeGreaterThan(0);
+  });
+
+  it('deve impedir redistribuição quando não há candidatos suficientes nas agendas seguintes', () => {
+    const sessoes = [
+      criarPeriodo({ id: 1, classificacao: 10, horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 2, classificacao: 5, horario: '11:00 às 12:00' }),
+    ];
+
+    const resultado = simularRedistribuicaoClassificacao(sessoes, 0, 20);
+
+    expect(resultado.valid).toBe(false);
+    expect(resultado.carryRestante).toBeLessThan(0);
+  });
+
+  it('deve permitir aumento quando agendas seguintes possuem candidatos para remover', () => {
+    const sessoes = [
+      criarPeriodo({ id: 1, classificacao: 20, horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 2, classificacao: 10, horario: '11:00 às 12:00' }),
+    ];
+
+    const resultado = simularRedistribuicaoClassificacao(sessoes, 0, 25);
+
+    expect(resultado).toEqual({ valid: true, carryRestante: 0 });
+  });
+
+  it('deve distribuir excedente apenas nas agendas subsequentes', () => {
+    const sessoes = [
+      criarPeriodo({ id: 1, classificacao: 10, horario: '10:00 às 11:00' }),
+      criarPeriodo({ id: 2, classificacao: 10, horario: '11:00 às 12:00' }),
+      criarPeriodo({ id: 3, classificacao: 10, horario: '12:00 às 13:00' }),
+    ];
+
+    const resultado = simularRedistribuicaoClassificacao(sessoes, 1, 5);
+
+    expect(resultado).toEqual({ valid: true, carryRestante: 0 });
+  });
+});
+
+describe('MENSAGEM_LIMITE_REDISTRIBUICAO', () => {
+  it('deve conter mensagem sobre limite de 30 candidatos', () => {
+    expect(MENSAGEM_LIMITE_REDISTRIBUICAO).toContain('30');
+    expect(MENSAGEM_LIMITE_REDISTRIBUICAO).toContain('outras agendas');
+  });
+
+  it('deve usar o mesmo limite exportado pela constante', () => {
+    expect(MAX_CANDIDATOS_POR_AGENDA).toBe(30);
+  });
+});

--- a/src/pages/CriarEditarConvocacao/Agenda/__tests__/useAgendaSchema.test.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/__tests__/useAgendaSchema.test.tsx
@@ -1,0 +1,83 @@
+import dayjs from 'dayjs';
+import useAgendaSchema from '../hooks/useAgendaSchema';
+
+const criarDadosPresencialValidos = () => ({
+  tipoEscolha: 'PRESENCIAL',
+  cargoAgenda: 'Professor',
+  escolhaEm: dayjs().add(1, 'day'),
+  nomeacaoEm: dayjs().add(2, 'day'),
+  quantidadeClassificados: 20,
+  sessao: 2,
+  horaInicio: dayjs().hour(10).minute(0).second(0).millisecond(0),
+  horaFim: dayjs().hour(11).minute(0).second(0).millisecond(0),
+});
+
+describe('useAgendaSchema - CriarEditarConvocacao', () => {
+  let schema: ReturnType<typeof useAgendaSchema>;
+
+  beforeEach(() => {
+    schema = useAgendaSchema();
+  });
+
+  describe('limite de candidatos por sessão', () => {
+    it('deve aceitar quantidade e sessões compatíveis com o limite de 30', async () => {
+      await expect(schema.validate(criarDadosPresencialValidos())).resolves.toBeDefined();
+    });
+
+    it('deve rejeitar quando candidatos por sessão ultrapassam 30', async () => {
+      await expect(
+        schema.validate({
+          ...criarDadosPresencialValidos(),
+          quantidadeClassificados: 100,
+          sessao: 2,
+        })
+      ).rejects.toThrow(/Limite de 30 candidatos por sessão/);
+    });
+
+    it('deve sugerir quantidade mínima de sessões necessárias', async () => {
+      await expect(
+        schema.validate({
+          ...criarDadosPresencialValidos(),
+          quantidadeClassificados: 100,
+          sessao: 2,
+        })
+      ).rejects.toThrow(/Sugestão: 4 sessão\(ões\)/);
+    });
+  });
+
+  describe('intervalo de horário', () => {
+    it('deve aceitar intervalo exatamente de 1 hora', async () => {
+      await expect(schema.validate(criarDadosPresencialValidos())).resolves.toBeDefined();
+    });
+
+    it('deve rejeitar intervalo diferente de 1 hora', async () => {
+      await expect(
+        schema.validate({
+          ...criarDadosPresencialValidos(),
+          horaInicio: dayjs().hour(10).minute(0).second(0).millisecond(0),
+          horaFim: dayjs().hour(12).minute(0).second(0).millisecond(0),
+        })
+      ).rejects.toThrow('Intervalo permitido: somente 1h');
+    });
+
+    it('deve rejeitar horário de início fora da janela 10h-17h', async () => {
+      await expect(
+        schema.validate({
+          ...criarDadosPresencialValidos(),
+          horaInicio: dayjs().hour(9).minute(0).second(0).millisecond(0),
+          horaFim: dayjs().hour(10).minute(0).second(0).millisecond(0),
+        })
+      ).rejects.toThrow(/Horário deve estar entre 10:00 e 17:00/);
+    });
+
+    it('deve rejeitar horário de fim fora da janela 10h-17h', async () => {
+      await expect(
+        schema.validate({
+          ...criarDadosPresencialValidos(),
+          horaInicio: dayjs().hour(16).minute(0).second(0).millisecond(0),
+          horaFim: dayjs().hour(18).minute(0).second(0).millisecond(0),
+        })
+      ).rejects.toThrow(/Horário deve estar entre 10:00 e 17:00/);
+    });
+  });
+});

--- a/src/pages/CriarEditarConvocacao/Agenda/components/AgendaForm.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/components/AgendaForm.tsx
@@ -19,6 +19,9 @@ import { agendaFormStyles } from "../styles";
 
 const { Text } = Typography;
 
+const HORA_INICIO_MIN = 10;
+const HORA_FIM_MAX = 17;
+
 interface AgendaFormProps {
   agendaAberto: any;
   handleFecharAgenda: () => void;
@@ -57,6 +60,29 @@ const AgendaForm: React.FC<AgendaFormProps> = ({
   hasAgendas,
 }) => {
   if (!agendaAberto) return null;
+
+  const disabledTime = (_date: any, type: "start" | "end") => {
+    const disabledHours = () => {
+      const hours: number[] = [];
+      for (let h = 0; h < 24; h++) {
+        const isAllowed = h >= HORA_INICIO_MIN && h <= HORA_FIM_MAX;
+        if (!isAllowed) hours.push(h);
+      }
+      // Para garantir 1h de intervalo, start não pode iniciar às 17 e end não pode terminar às 10
+      if (type === "start") {
+        if (!hours.includes(HORA_FIM_MAX)) hours.push(HORA_FIM_MAX);
+      } else {
+        if (!hours.includes(HORA_INICIO_MIN)) hours.push(HORA_INICIO_MIN);
+      }
+      return hours.sort((a, b) => a - b);
+    };
+
+    // Mantém minutos/segundos livres; a validação do intervalo (1h) acontece no schema.
+    return {
+      disabledHours,
+    };
+  };
+
   return (
     <Card
       style={agendaFormStyles.agendaCard}
@@ -284,6 +310,7 @@ const AgendaForm: React.FC<AgendaFormProps> = ({
                           placeholder={["Início", "Fim"]}
                           style={agendaFormStyles.timePickerRange}
                           format="HH:mm"
+                          disabledTime={disabledTime}
                           onChange={async (times) => {
                             if (times && times.length === 2) {
                               field.onChange(times[0]);

--- a/src/pages/CriarEditarConvocacao/Agenda/components/AgendaTabela.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/components/AgendaTabela.tsx
@@ -10,10 +10,23 @@ import {
 import { CalendarOutlined, DownOutlined, DeleteOutlined, CheckOutlined, CloseOutlined, EditOutlined } from "@ant-design/icons";
 import { useForm, Controller } from "react-hook-form";
 import dayjs from "dayjs";
-import type { PeriodoItem } from "../hooks/useAgenda";
+import { MENSAGEM_LIMITE_REDISTRIBUICAO, type PeriodoItem } from "../hooks/useAgenda";
 import { commonStyles, inlineStyles, agendaTabelaStyles } from "../styles";
 
 const { Text } = Typography;
+
+const INTERVALO_UMA_HORA_MSG = "Intervalo permitido: somente 1h.";
+
+const isIntervaloUmaHora = (horaInicio?: string, horaFim?: string): boolean => {
+  if (!horaInicio || !horaFim) return true;
+
+  const inicio = dayjs(`2000-01-01 ${horaInicio}`);
+  const fim = dayjs(`2000-01-01 ${horaFim}`);
+
+  if (!inicio.isValid() || !fim.isValid()) return true;
+
+  return fim.diff(inicio, "minute") === 60;
+};
 
 interface FormData {
   [key: string]: {
@@ -35,6 +48,11 @@ interface AgendaTabelaProps {
   saveEdit: (key: number, periodoDataItem: PeriodoItem, values: any) => { success: boolean; message?: string };
   calcularIntervaloClassificacao: (periodo: PeriodoItem) => string;
   verificarConflitoTempoReal: (key: number, horaInicio: string | number | undefined, horaFim: string | number | undefined) => boolean;
+  validarRedistribuicaoClassificacao: (
+    key: number,
+    periodoDataItem: PeriodoItem,
+    novaClassificacao: number
+  ) => { valid: boolean; message?: string };
   cargoParaExpandir: string | null;
   limparExpansao: () => void;
 }
@@ -51,6 +69,7 @@ const AgendaTabela: React.FC<AgendaTabelaProps> = ({
   saveEdit,
   calcularIntervaloClassificacao,
   verificarConflitoTempoReal,
+  validarRedistribuicaoClassificacao,
   cargoParaExpandir,
   limparExpansao,
 }) => {
@@ -191,6 +210,7 @@ const AgendaTabela: React.FC<AgendaTabelaProps> = ({
             <AgendaTabelaExpandida
               key={formResetKey}
               periodosList={periodosDoCargo}
+              totalCandidatosCargo={record.cargoData?.totalCandidatos ?? 0}
               handleRemoverPeriodo={handleRemoverPeriodo}
               editingKey={editingKey}
               isEditing={isEditing}
@@ -199,6 +219,7 @@ const AgendaTabela: React.FC<AgendaTabelaProps> = ({
               saveEdit={saveEdit}
               calcularIntervaloClassificacao={calcularIntervaloClassificacao}
               verificarConflitoTempoReal={verificarConflitoTempoReal}
+              validarRedistribuicaoClassificacao={validarRedistribuicaoClassificacao}
             />
           );
         },
@@ -229,9 +250,34 @@ const AgendaTabela: React.FC<AgendaTabelaProps> = ({
   );
 };
 
+const getMaxClassificacaoSessao = (
+  totalCandidatosCargo: number,
+  periodosList: PeriodoItem[],
+  record: PeriodoItem
+): number | undefined => {
+  const MAX_CANDIDATOS_POR_AGENDA = 30;
+  if (record.isRetardatario || record.tipoEscolha !== "PRESENCIAL") {
+    return undefined;
+  }
+
+  const numeroSessoes = periodosList.filter(
+    (periodo) => !periodo.isRetardatario && periodo.tipoEscolha === "PRESENCIAL"
+  ).length;
+
+  if (numeroSessoes <= 0 || totalCandidatosCargo <= 0) {
+    return undefined;
+  }
+
+  return Math.min(
+    MAX_CANDIDATOS_POR_AGENDA,
+    Math.max(1, totalCandidatosCargo - (numeroSessoes - 1))
+  );
+};
+
 // Componente da tabela expandida integrado
 const AgendaTabelaExpandida: React.FC<{
   periodosList: PeriodoItem[];
+  totalCandidatosCargo: number;
   handleRemoverPeriodo: (id: number) => void;
   editingKey: number | null;
   isEditing: (record: PeriodoItem) => boolean;
@@ -240,8 +286,14 @@ const AgendaTabelaExpandida: React.FC<{
   saveEdit: (key: number, periodoDataItem: PeriodoItem, values: any) => { success: boolean; message?: string };
   calcularIntervaloClassificacao: (periodo: PeriodoItem) => string;
   verificarConflitoTempoReal: (key: number, horaInicio: string | number | undefined, horaFim: string | number | undefined) => boolean;
+  validarRedistribuicaoClassificacao: (
+    key: number,
+    periodoDataItem: PeriodoItem,
+    novaClassificacao: number
+  ) => { valid: boolean; message?: string };
 }> = ({
   periodosList,
+  totalCandidatosCargo,
   handleRemoverPeriodo,
   editingKey,
   isEditing,
@@ -250,8 +302,9 @@ const AgendaTabelaExpandida: React.FC<{
   saveEdit,
   calcularIntervaloClassificacao,
   verificarConflitoTempoReal,
+  validarRedistribuicaoClassificacao,
 }) => {
-  const { control, getValues, reset } = useForm<FormData>({
+  const { control, getValues, reset, watch } = useForm<FormData>({
     defaultValues: periodosList.reduce((acc, item) => {
       acc[item.id.toString()] = {
         horaInicio: item.horaInicio || '',
@@ -261,6 +314,8 @@ const AgendaTabelaExpandida: React.FC<{
       return acc;
     }, {} as FormData),
   });
+
+  const formValues = watch();
 
   const cancel = () => {
     cancelEdit();
@@ -282,9 +337,17 @@ const AgendaTabelaExpandida: React.FC<{
     };
     
     const result = saveEdit(key, periodoDataItem, values);
-    
+
     if (!result.success) {
-      message.error(result.message || 'Erro ao salvar período.');
+      const errosInline =
+        result.message === INTERVALO_UMA_HORA_MSG ||
+        result.message === 'Este horário já existe na mesma data. Escolha outro horário.' ||
+        result.message === MENSAGEM_LIMITE_REDISTRIBUICAO ||
+        result.message === "Valor inválido para redistribuição. Não há candidatos suficientes nas agendas seguintes.";
+
+      if (!errosInline) {
+        message.error(result.message || 'Erro ao salvar período.');
+      }
     }
   };
 
@@ -298,25 +361,56 @@ const AgendaTabelaExpandida: React.FC<{
       editable: true,
       render: (_: number, record: PeriodoItem) => {
         const editing = isEditing(record);
+        const maxClassificacao = getMaxClassificacaoSessao(totalCandidatosCargo, periodosList, record);
+        const classificacaoAtual = Number(
+          formValues[record.id.toString()]?.classificacao ?? record.classificacao ?? 1
+        );
+        const validacaoRedistribuicao = editing
+          ? validarRedistribuicaoClassificacao(record.id, record, classificacaoAtual)
+          : { valid: true };
+        const temErroClassificacao = !validacaoRedistribuicao.valid;
+
         return editing ? (
-          <div style={agendaTabelaStyles.editContainer}>
-            <Controller
-              name={`${record.id}.classificacao`}
-              control={control}
-              defaultValue={record.classificacao || 1}
-              render={({ field }) => (
-                <input
-                  {...field}
-                  type="number"
-                  min="1"
-                  style={agendaTabelaStyles.editInput}
-                  placeholder="Quantidade"
-                />
-              )}
-            />
-            <Typography.Text style={agendaTabelaStyles.candidatosText}>
-              candidatos
-            </Typography.Text>
+          <div style={agendaTabelaStyles.editHorarioContainer}>
+            <div style={agendaTabelaStyles.editContainer}>
+              <Controller
+                name={`${record.id}.classificacao`}
+                control={control}
+                defaultValue={record.classificacao || 1}
+                render={({ field }) => (
+                  <input
+                    {...field}
+                    type="number"
+                    min={1}
+                    max={maxClassificacao}
+                    style={{
+                      ...agendaTabelaStyles.editInput,
+                      ...(temErroClassificacao ? { borderColor: '#ff4d4f' } : {}),
+                    }}
+                    onChange={(event) => {
+                      const parsed = Number(event.target.value);
+                      if (!Number.isFinite(parsed)) {
+                        field.onChange(event.target.value);
+                        return;
+                      }
+
+                      const valorLimitado = maxClassificacao
+                        ? Math.min(Math.max(parsed, 1), maxClassificacao)
+                        : Math.max(parsed, 1);
+
+                      field.onChange(valorLimitado);
+                    }}
+                  />
+                )}
+              />
+            </div>
+            {temErroClassificacao && validacaoRedistribuicao.message && (
+              <div style={agendaTabelaStyles.timeErrorContainer}>
+                <Typography.Text type="danger" style={agendaTabelaStyles.conflictText}>
+                  {validacaoRedistribuicao.message}
+                </Typography.Text>
+              </div>
+            )}
           </div>
         ) : (
           <div>
@@ -363,18 +457,23 @@ const AgendaTabelaExpandida: React.FC<{
       editable: true,
       render: (text: string, record: PeriodoItem) => {
         const editing = isEditing(record);
+        const horarioValues = formValues[record.id.toString()];
+        const horaInicio = horarioValues?.horaInicio || '';
+        const horaFim = horarioValues?.horaFim || '';
+        const temConflito = verificarConflitoTempoReal(record.id, horaInicio, horaFim);
+        const intervaloInvalido = Boolean(horaInicio && horaFim && !isIntervaloUmaHora(horaInicio, horaFim));
+        const temErroHorario = temConflito || intervaloInvalido;
+
         return editing ? (
-          <div style={agendaTabelaStyles.editContainer}>
+          <div style={agendaTabelaStyles.editHorarioContainer}>
             {record.tipoEscolha === "PRESENCIAL" ? (
               <>
-                <Controller
-                  name={`${record.id}.horaInicio`}
-                  control={control}
-                  defaultValue={record.horaInicio || ''}
-                  render={({ field }) => {
-                    const values = getValues(record.id.toString());
-                    const temConflito = verificarConflitoTempoReal(record.id, values?.horaInicio || '', values?.horaFim || '');
-                    return (
+                <div style={agendaTabelaStyles.editContainer}>
+                  <Controller
+                    name={`${record.id}.horaInicio`}
+                    control={control}
+                    defaultValue={record.horaInicio || ''}
+                    render={({ field }) => (
                       <TimePicker
                         {...field}
                         style={agendaTabelaStyles.editTimePicker}
@@ -382,21 +481,17 @@ const AgendaTabelaExpandida: React.FC<{
                         placeholder="Início"
                         value={field.value ? dayjs(field.value, 'HH:mm') : null}
                         onChange={(time) => field.onChange(time ? time.format('HH:mm') : '')}
-                        status={temConflito ? 'error' : undefined}
+                        status={temErroHorario ? 'error' : undefined}
                         suffixIcon={null}
                       />
-                    );
-                  }}
-                />
-                <Typography.Text strong style={agendaTabelaStyles.timeSeparator}>às</Typography.Text>
-                <Controller
-                  name={`${record.id}.horaFim`}
-                  control={control}
-                  defaultValue={record.horaFim || ''}
-                  render={({ field }) => {
-                    const values = getValues(record.id.toString());
-                    const temConflito = verificarConflitoTempoReal(record.id, values?.horaInicio || '', values?.horaFim || '');
-                    return (
+                    )}
+                  />
+                  <Typography.Text strong style={agendaTabelaStyles.timeSeparator}>às</Typography.Text>
+                  <Controller
+                    name={`${record.id}.horaFim`}
+                    control={control}
+                    defaultValue={record.horaFim || ''}
+                    render={({ field }) => (
                       <TimePicker
                         {...field}
                         style={agendaTabelaStyles.editTimePicker}
@@ -404,21 +499,26 @@ const AgendaTabelaExpandida: React.FC<{
                         placeholder="Fim"
                         value={field.value ? dayjs(field.value, 'HH:mm') : null}
                         onChange={(time) => field.onChange(time ? time.format('HH:mm') : '')}
-                        status={temConflito ? 'error' : undefined}
+                        status={temErroHorario ? 'error' : undefined}
                         suffixIcon={null}
                       />
-                    );
-                  }}
-                />
-                {(() => {
-                  const values = getValues(record.id.toString());
-                  const temConflito = verificarConflitoTempoReal(record.id, values?.horaInicio || '', values?.horaFim || '');
-                  return temConflito ? (
-                    <Typography.Text type="danger" style={agendaTabelaStyles.conflictText}>
-                      Horário já existe
-                    </Typography.Text>
-                  ) : null;
-                })()}
+                    )}
+                  />
+                </div>
+                {(intervaloInvalido || temConflito) && (
+                  <div style={agendaTabelaStyles.timeErrorContainer}>
+                    {intervaloInvalido && (
+                      <Typography.Text type="danger" style={agendaTabelaStyles.conflictText}>
+                        {INTERVALO_UMA_HORA_MSG}
+                      </Typography.Text>
+                    )}
+                    {temConflito && (
+                      <Typography.Text type="danger" style={agendaTabelaStyles.conflictText}>
+                        Horário já existe
+                      </Typography.Text>
+                    )}
+                  </div>
+                )}
               </>
             ) : (
               <Typography.Text style={agendaTabelaStyles.onlineText}>

--- a/src/pages/CriarEditarConvocacao/Agenda/hooks/useAgenda.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/hooks/useAgenda.tsx
@@ -56,6 +56,54 @@ export type PeriodoItem = {
   nomeacaoEm?: string;
 };
 
+export const MAX_CANDIDATOS_POR_AGENDA = 30;
+
+export const MENSAGEM_LIMITE_REDISTRIBUICAO =
+  "O valor não pode ser alterado pois ultrapassaria o limite de 30 candidatos nas outras agendas.";
+
+export const ordenarSessoesPresenciais = (periodos: PeriodoItem[], cargo: string) =>
+  periodos
+    .filter((periodo) => periodo.cargo === cargo && !periodo.isRetardatario && periodo.tipoEscolha === "PRESENCIAL")
+    .sort((a, b) => {
+      if (a.dataEscolha !== b.dataEscolha) {
+        return a.dataEscolha.localeCompare(b.dataEscolha);
+      }
+      return a.horario.localeCompare(b.horario);
+    });
+
+export const simularRedistribuicaoClassificacao = (
+  sessoesOrdenadas: PeriodoItem[],
+  idxEdicao: number,
+  novaClassificacao: number,
+  maxPorSessao = MAX_CANDIDATOS_POR_AGENDA
+): { valid: boolean; carryRestante: number } => {
+  const sessaoEditada = sessoesOrdenadas[idxEdicao];
+  const novaClassificacaoLimitada = Math.min(novaClassificacao, maxPorSessao);
+
+  if (!sessaoEditada || novaClassificacaoLimitada < 1) {
+    return { valid: false, carryRestante: 0 };
+  }
+
+  let carry = (sessaoEditada.classificacao ?? 0) - novaClassificacaoLimitada;
+
+  for (let i = idxEdicao + 1; i < sessoesOrdenadas.length; i++) {
+    if (carry === 0) break;
+
+    const sessao = sessoesOrdenadas[i];
+    const atual = sessao.classificacao ?? 1;
+
+    if (carry > 0) {
+      const espaco = Math.max(0, maxPorSessao - atual);
+      carry -= Math.min(carry, espaco);
+    } else {
+      const removivel = Math.max(0, atual - 1);
+      carry += Math.min(-carry, removivel);
+    }
+  }
+
+  return { valid: carry === 0, carryRestante: carry };
+};
+
 export const useAgenda = () => {
   const { uuid } = useParams<{ uuid: string }>();
   
@@ -103,7 +151,6 @@ export const useAgenda = () => {
     [uuid, processoConvocacaoData]
   );
   const { agendasData, agendasIsLoading } = useGetAgendas(agendasListRequest);
-  console.log("agendasData", agendasData);
 
   // Quando a primeira agenda for ONLINE, a API pode retornar a lista de candidatos faltantes
   // Preferir a nova chave candidatos_faltantes_uuids; manter compatibilidade com candidatos_uuids_restantes
@@ -789,80 +836,88 @@ export const useAgenda = () => {
   // Função para atualizar período na tabela
   const handleUpdatePeriodo = (id: number, updates: Partial<PeriodoItem>) => {
     setPeriodosList(prev => {
-      // Encontrar o período que está sendo atualizado
       const periodoAtual = prev.find(p => p.id === id);
       if (!periodoAtual) return prev;
 
-      // Se não há mudança na classificação, apenas atualizar normalmente
-      if (!updates.classificacao || updates.classificacao === periodoAtual.classificacao) {
-        return prev.map(periodo => {
-          if (periodo.id === id) {
-            return { ...periodo, ...updates };
-          }
-          return periodo;
-        });
+      const atualizarPeriodo = (lista: PeriodoItem[]) =>
+        lista.map(periodo => (periodo.id === id ? { ...periodo, ...updates } : periodo));
+
+      const deveBalancear =
+        updates.classificacao !== undefined &&
+        updates.classificacao !== periodoAtual.classificacao &&
+        !periodoAtual.isRetardatario &&
+        periodoAtual.tipoEscolha === "PRESENCIAL";
+
+      if (!deveBalancear) {
+        return atualizarPeriodo(prev);
       }
 
-      // Encontrar todos os períodos do mesmo cargo, ordenados por data e horário
-      const periodosMesmoCargo = prev
-        .filter(p => p.cargo === periodoAtual.cargo)
+      const MAX_CANDIDATOS_POR_AGENDA = 30;
+
+      const cargo = cargosAdicionados.find(
+        (item) => item.uuid === periodoAtual.cargoUuid || item.nome === periodoAtual.cargo
+      );
+      const totalCandidatos = cargo?.totalCandidatos ?? 0;
+
+      const sessoesOrdenadas = prev
+        .filter(
+          (periodo) =>
+            periodo.cargo === periodoAtual.cargo &&
+            !periodo.isRetardatario &&
+            periodo.tipoEscolha === "PRESENCIAL"
+        )
         .sort((a, b) => {
-          // Ordenar por data e depois por horário
           if (a.dataEscolha !== b.dataEscolha) {
             return a.dataEscolha.localeCompare(b.dataEscolha);
           }
           return a.horario.localeCompare(b.horario);
         });
 
-      // Encontrar o índice do período atual na lista ordenada
-      const indiceAtual = periodosMesmoCargo.findIndex(p => p.id === id);
-      
-      // Se não há próximo período, apenas atualizar o atual
-      if (indiceAtual === -1 || indiceAtual >= periodosMesmoCargo.length - 1) {
-        return prev.map(periodo => {
-          if (periodo.id === id) {
-            return { ...periodo, ...updates };
-          }
-          return periodo;
-        });
+      const idx = sessoesOrdenadas.findIndex((p) => p.id === id);
+      if (idx === -1) {
+        return atualizarPeriodo(prev);
       }
 
-      // Encontrar o próximo período do mesmo cargo
-      const proximoPeriodo = periodosMesmoCargo[indiceAtual + 1];
-      
-      // Calcular a diferença na classificação
-      const diferenca = periodoAtual.classificacao - updates.classificacao;
+      const anterior = sessoesOrdenadas[idx];
+      const novaClassificacao = updates.classificacao as number;
+      // Garantir o teto de 30 aqui também
+      const novaClassificacaoLimitada = Math.min(novaClassificacao, MAX_CANDIDATOS_POR_AGENDA);
 
-      // Calcular o novo valor de classificação para o próximo período
-      const novaClassificacaoProximo = proximoPeriodo.classificacao + diferenca;
-      
-      // Se a diferença for menor ou igual a 0, apenas atualizar o período atual
-      if (diferenca <= 0) {
-        return prev.map(periodo => {
-          if (periodo.id === id) {
-            return { ...periodo, ...updates };
-          } else if (periodo.id === proximoPeriodo.id) {
-            // Atualizar o próximo período com a classificação ajustada
-            return { 
-              ...periodo, 
-              classificacao: parseInt(novaClassificacaoProximo.toString()) 
-            };
-          }
-          return periodo;
-        });
+      // carry > 0: sobrou candidato (precisa adicionar nas próximas)
+      // carry < 0: faltou candidato (precisa remover das próximas)
+      let carry = (anterior.classificacao ?? 0) - novaClassificacaoLimitada;
+
+      const novosValores = new Map<number, number>();
+
+      for (let i = idx + 1; i < sessoesOrdenadas.length; i++) {
+        if (carry === 0) break;
+
+        const sessao = sessoesOrdenadas[i];
+        const atual = sessao.classificacao ?? 1;
+
+        if (carry > 0) {
+          const espaco = Math.max(0, MAX_CANDIDATOS_POR_AGENDA - atual);
+          const add = Math.min(carry, espaco);
+          novosValores.set(sessao.id, atual + add);
+          carry -= add;
+        } else {
+          const removivel = Math.max(0, atual - 1);
+          const remove = Math.min(-carry, removivel);
+          novosValores.set(sessao.id, atual - remove);
+          carry += remove;
+        }
       }
 
-      // Atualizar ambos os períodos
-      return prev.map(periodo => {
+      // Se ainda sobrar carry, mantém o que deu para fazer (o saveEdit deve impedir casos inválidos)
+      // Reforço: se carry > 0 aqui, significa que não coube nas próximas sem passar de 30.
+      // Se carry < 0, significa que não foi possível tirar o suficiente das próximas sem cair abaixo de 1.
+
+      return prev.map((periodo) => {
         if (periodo.id === id) {
-          // Atualizar o período atual
-          return { ...periodo, ...updates };
-        } else if (periodo.id === proximoPeriodo.id) {
-          // Atualizar o próximo período com a classificação ajustada
-          return { 
-            ...periodo, 
-            classificacao: parseInt(novaClassificacaoProximo.toString()) 
-          };
+          return { ...periodo, ...updates, classificacao: novaClassificacaoLimitada };
+        }
+        if (novosValores.has(periodo.id)) {
+          return { ...periodo, classificacao: novosValores.get(periodo.id)! };
         }
         return periodo;
       });
@@ -1047,6 +1102,52 @@ export const useAgenda = () => {
     return verificarHorarioExistente(key, horaInicio, horaFim);
   };
 
+  const validarRedistribuicaoClassificacao = useCallback(
+    (key: number, periodoDataItem: PeriodoItem, novaClassificacao: number) => {
+      if (periodoDataItem?.tipoEscolha !== "PRESENCIAL" || periodoDataItem?.isRetardatario) {
+        return { valid: true };
+      }
+
+      const classificacaoNumerica = Number(novaClassificacao);
+      if (!Number.isFinite(classificacaoNumerica)) {
+        return { valid: false };
+      }
+
+      if (classificacaoNumerica > MAX_CANDIDATOS_POR_AGENDA) {
+        return {
+          valid: false,
+          message: `Máximo de ${MAX_CANDIDATOS_POR_AGENDA} candidatos por agenda.`,
+        };
+      }
+
+      const sessoesOrdenadas = ordenarSessoesPresenciais(periodosList, periodoDataItem.cargo);
+      const idx = sessoesOrdenadas.findIndex((periodo) => periodo.id === key);
+      if (idx === -1) {
+        return { valid: true };
+      }
+
+      const { valid, carryRestante } = simularRedistribuicaoClassificacao(
+        sessoesOrdenadas,
+        idx,
+        classificacaoNumerica
+      );
+
+      if (!valid) {
+        if (carryRestante > 0) {
+          return { valid: false, message: MENSAGEM_LIMITE_REDISTRIBUICAO };
+        }
+
+        return {
+          valid: false,
+          message: "Valor inválido para redistribuição. Não há candidatos suficientes nas agendas seguintes.",
+        };
+      }
+
+      return { valid: true };
+    },
+    [periodosList]
+  );
+
   // Função para verificar se um período está sendo editado
   const isEditing = (record: PeriodoItem) => record.id === editingKey;
 
@@ -1068,11 +1169,32 @@ export const useAgenda = () => {
         if (!values.horaInicio || !values.horaFim) {
           return { success: false, message: 'Horários são obrigatórios para tipo Presencial.' };
         }
+
+        // Intervalo permitido: somente 1h
+        const inicio = dayjs(`2000-01-01 ${values.horaInicio}`);
+        const fim = dayjs(`2000-01-01 ${values.horaFim}`);
+        if (!inicio.isValid() || !fim.isValid() || fim.diff(inicio, "minute") !== 60) {
+          return { success: false, message: "Intervalo permitido: somente 1h." };
+        }
         
         // Verificar se o horário já existe na mesma data
         if (verificarHorarioExistente(key, values.horaInicio, values.horaFim)) {
           return { success: false, message: 'Este horário já existe na mesma data. Escolha outro horário.' };
         }
+      }
+
+      const classificacaoNumerica = parseInt(values.classificacao);
+
+      const validacaoRedistribuicao = validarRedistribuicaoClassificacao(
+        key,
+        periodoDataItem,
+        classificacaoNumerica
+      );
+      if (!validacaoRedistribuicao.valid) {
+        return {
+          success: false,
+          message: validacaoRedistribuicao.message || "Valor inválido para redistribuição.",
+        };
       }
       
       let horarioFormatado: string;
@@ -1097,7 +1219,7 @@ export const useAgenda = () => {
         horario: horarioFormatado,
         horaInicioOriginal: horaInicioOriginal,
         horaFimOriginal: horaFimOriginal,
-        classificacao: parseInt(values.classificacao)
+        classificacao: classificacaoNumerica
       };
       handleUpdatePeriodo(key, updates);
       
@@ -1309,6 +1431,7 @@ export const useAgenda = () => {
     calcularIntervaloClassificacao,
     verificarHorarioExistente,
     verificarConflitoTempoReal,
+    validarRedistribuicaoClassificacao,
     // Estados e funções para expansão automática
     cargoParaExpandir,
     limparExpansao,

--- a/src/pages/CriarEditarConvocacao/Agenda/hooks/useAgendaSchema.tsx
+++ b/src/pages/CriarEditarConvocacao/Agenda/hooks/useAgendaSchema.tsx
@@ -25,6 +25,10 @@ const useAgendaSchema = (
   isRetardatario?: () => boolean,
   verificarHorarioRetardatario?: () => boolean
 ) => {
+  const MAX_CANDIDATOS_POR_SESSAO = 30;
+  const HORA_INICIO_MIN = 10;
+  const HORA_FIM_MAX = 17;
+
   return yup.object({
     tipoEscolha: yup
       .string()
@@ -200,6 +204,36 @@ const useAgendaSchema = (
           return true;
         }
         return Number.isInteger(value);
+      })
+      .test("max-candidatos-por-sessao", function(value) {
+        const { quantidadeClassificados, tipoEscolha } = this.parent as IAgendaFields;
+        const isRetardatarioValue = isRetardatario?.();
+        // Regra só se aplica para PRESENCIAL não-retardatário.
+        if (isRetardatarioValue || tipoEscolha !== "PRESENCIAL") {
+          return true;
+        }
+
+        if (quantidadeClassificados === null || quantidadeClassificados === undefined) {
+          return true;
+        }
+
+        if (value === null || value === undefined) {
+          return true;
+        }
+
+        if (value <= 0) {
+          return true;
+        }
+
+        const candidatosPorSessao = Math.ceil(Number(quantidadeClassificados) / Number(value));
+        if (candidatosPorSessao <= MAX_CANDIDATOS_POR_SESSAO) {
+          return true;
+        }
+
+        const sugestaoSessoes = Math.ceil(Number(quantidadeClassificados) / MAX_CANDIDATOS_POR_SESSAO);
+        return this.createError({
+          message: `Limite de ${MAX_CANDIDATOS_POR_SESSAO} candidatos por sessão. Sugestão: ${sugestaoSessoes} sessão(ões).`,
+        });
       }),
     
     horaInicio: yup
@@ -211,6 +245,16 @@ const useAgendaSchema = (
           .test("is-valid-time", "Hora de início inválida", (value) => {
             return value && dayjs(value as any).isValid();
           })
+          .test(
+            "is-within-window",
+            `Horário deve estar entre ${HORA_INICIO_MIN}:00 e ${HORA_FIM_MAX}:00`,
+            (value) => {
+              if (!value) return true;
+              const d = dayjs(value as any);
+              const h = d.hour();
+              return h >= HORA_INICIO_MIN && h < HORA_FIM_MAX;
+            }
+          )
           .test("retardatario-deve-ser-ultimo", "O horário do retardatário deve ser depois de todas as outras agendas", function(value) {
             const isRetardatarioValue = isRetardatario?.();
             if (!isRetardatarioValue || !value) {
@@ -242,6 +286,23 @@ const useAgendaSchema = (
             const horaFim = dayjs(value as any);
             const horaInicioTime = dayjs(horaInicio as any);
             return horaFim.isAfter(horaInicioTime);
+          })
+          .test(
+            "is-within-window",
+            `Horário deve estar entre ${HORA_INICIO_MIN}:00 e ${HORA_FIM_MAX}:00`,
+            (value) => {
+              if (!value) return true;
+              const d = dayjs(value as any);
+              const h = d.hour();
+              return h > HORA_INICIO_MIN && h <= HORA_FIM_MAX;
+            }
+          )
+          .test("is-one-hour", "Intervalo permitido: somente 1h", function(value) {
+            const { horaInicio } = this.parent;
+            if (!value || !horaInicio) return true;
+            const fim = dayjs(value as any);
+            const inicio = dayjs(horaInicio as any);
+            return fim.diff(inicio, "minute") === 60;
           }),
         otherwise: (schema) => schema.notRequired(),
       }),

--- a/src/pages/CriarEditarConvocacao/Agenda/styles.ts
+++ b/src/pages/CriarEditarConvocacao/Agenda/styles.ts
@@ -391,6 +391,11 @@ export const agendaFormStyles = {
     width: '100%',
     height: '2.8125rem'
   },
+
+  // Container de erros do intervalo de horário
+  timeErrorContainer: {
+    marginTop: 4,
+  },
   
   // Informação de candidatos disponíveis
   candidatosDisponiveis: {
@@ -456,6 +461,19 @@ export const agendaTabelaStyles = {
   // Texto de conflito
   conflictText: {
     fontSize: '0.625rem'
+  },
+
+  // Container do horário em edição (campos + mensagens de erro)
+  editHorarioContainer: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    gap: 4,
+  },
+
+  timeErrorContainer: {
+    marginTop: 4,
+    textAlign: 'center' as const,
   },
   
   // Texto online

--- a/src/pages/CriarEditarConvocacao/Agenda/testHelpers/useAgendaMocks.ts
+++ b/src/pages/CriarEditarConvocacao/Agenda/testHelpers/useAgendaMocks.ts
@@ -1,0 +1,39 @@
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ uuid: 'test-uuid' }),
+}));
+
+jest.mock('../../SelecaoCargos/hooks/useGetProcessosConvocacaoPorUUID.tsx', () => ({
+  useGetProcessosConvocacaoPorUUID: () => ({ data: undefined, isLoading: false }),
+}));
+
+jest.mock('../../SelecaoCargos/hooks/useGetConcursosPorUuid.tsx', () => ({
+  useGetConcursoByUuid: () => ({ data: undefined }),
+}));
+
+jest.mock('../hooks/usePostAgenda', () => ({
+  usePostAgenda: () => ({ mutateAsync: jest.fn() }),
+}));
+
+jest.mock('../hooks/useDeleteAgenda', () => ({
+  useDeleteAgenda: () => ({ mutateAsync: jest.fn() }),
+}));
+
+jest.mock('../hooks/useGetAgendas', () => ({
+  useGetAgendas: () => ({ data: undefined }),
+}));
+
+jest.mock('../../../../services/resources/convocacao', () => ({
+  getCargosProcesso: jest.fn(),
+}));
+
+jest.mock('@hookform/resolvers/yup', () => ({
+  yupResolver: jest.fn(),
+}));
+
+jest.mock('../hooks/useAgendaSchema', () => ({
+  __esModule: true,
+  default: () => ({}),
+}));
+
+export {};


### PR DESCRIPTION
## Resumo

- Implementa regras de negócio para agendas presenciais: máximo de 30 candidatos por sessão, janela de horário das 10h às 17h e intervalo fixo de 1 hora entre início e fim.
- Adiciona redistribuição automática de candidatos entre sessões ao editar a quantidade na tabela, com validação que impede alterações que ultrapassem o limite de 30 nas agendas seguintes.
- Exibe mensagens de erro inline abaixo dos campos de horário e quantidade de candidatos durante a edição, evitando toasts duplicados para erros já visíveis na tela.
- Inclui testes unitários para redistribuição, schema de validação e comportamento da `AgendaTabela`.
- 
## Detalhes das alterações

### Formulário de criação (`AgendaForm` + `useAgendaSchema`)
- Valida que `quantidadeClassificados / sessao` não ultrapasse 30, sugerindo a quantidade mínima de sessões necessária.
- Restringe seleção de horário à janela 10:00–17:00 via `disabledTime` no `TimePicker`.
- Valida que o intervalo entre início e fim seja exatamente 1 hora.
- 
### Edição na tabela (`AgendaTabela` + `useAgenda`)
- Ao diminuir candidatos em uma sessão, redistribui o excedente para as agendas seguintes do mesmo cargo.
- Bloqueia salvamento e exibe erro inline quando a redistribuição faria alguma agenda seguinte passar de 30 candidatos.
- Valida intervalo de 1 hora na edição de horário, com feedback visual (borda vermelha + mensagem abaixo do campo).
- Calcula o máximo permitido por sessão com base no total de candidatos e no número de sessões.
- 
### Outros
- Ajuste nos breadcrumbs da `AgendaTela` (remoção do item "Home").
- Novos testes: `useAgendaRedistribuicao.test.ts`, `useAgendaSchema.test.tsx`, `AgendaTabela.test.tsx`.

[AB#152030](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/152030) [AB#151954](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/151954)