### PR TITLE
feat(152901): adiciona steps navegáveis no cadastro de concurso

### DIFF
--- a/src/pages/Gerenciar/CadastroConcursos/passos/IdentificacaoTela.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/IdentificacaoTela.tsx
@@ -18,8 +18,6 @@ const IdentificacaoTela: React.FC = () => {
   const navigate = useNavigate();
   const current = 0;
 
-  // Passo 1 "cria" o concurso gerando um uuid no cliente, que é carregado
-  // por parâmetro nos passos seguintes. Nenhum request ao backend nesta fase.
   const [uuidConcurso] = useState(() => uuidv4());
 
   const { stepItems, handleStepChange } = useConcursoSteps({

--- a/src/pages/Gerenciar/CadastroConcursos/passos/IdentificacaoTela.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/IdentificacaoTela.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import { Steps, Typography } from "antd";
+import { useNavigate } from "react-router-dom";
+import { v4 as uuidv4 } from "uuid";
+import BaseTela, { type TitleItem } from "../../../Base/BaseTela";
+import { StepActionsConcurso } from "./StepActionsConcurso";
+import { steps } from "./stepsConcurso";
+import { useConcursoSteps } from "./useConcursoSteps";
+import {
+  CardTitle,
+  ConvocacaoStepsGlobalStyle,
+  StyledCardWithoutBorder,
+} from "@/components/ui";
+
+const { Text } = Typography;
+
+const IdentificacaoTela: React.FC = () => {
+  const navigate = useNavigate();
+  const current = 0;
+
+  // Passo 1 "cria" o concurso gerando um uuid no cliente, que é carregado
+  // por parâmetro nos passos seguintes. Nenhum request ao backend nesta fase.
+  const [uuidConcurso] = useState(() => uuidv4());
+
+  const { stepItems, handleStepChange } = useConcursoSteps({
+    uuid: uuidConcurso,
+    currentStepIndex: current,
+    onNavigate: (path) => navigate(path),
+  });
+
+  const breadcrumbItems = [
+    { title: <Text strong>Gerenciar</Text> },
+    {
+      title: (
+        <Text
+          style={{ cursor: "pointer" }}
+          onClick={() => navigate("/gerenciar/concursos")}
+        >
+          Cadastro de concurso
+        </Text>
+      ),
+    },
+    { title: "Adicionar concurso" },
+  ] as TitleItem[];
+
+  const next = () => {
+    navigate(`/gerenciar/concursos/adicionar/${uuidConcurso}/passo-2`);
+  };
+
+  const prev = () => {
+    navigate("/gerenciar/concursos");
+  };
+
+  const cancel = () => {
+    navigate("/gerenciar/concursos");
+  };
+
+  return (
+    <>
+      <ConvocacaoStepsGlobalStyle />
+      <BaseTela breadcrumbItems={breadcrumbItems} title="Adicionar concurso">
+        <StyledCardWithoutBorder variant="borderless">
+          <Steps
+            className="convocacao-steps"
+            current={current}
+            items={stepItems}
+            onChange={handleStepChange}
+          />
+        </StyledCardWithoutBorder>
+
+        <StyledCardWithoutBorder
+          style={{ marginTop: "1.25rem" }}
+          variant="borderless"
+        >
+          <CardTitle>Identificação do concurso</CardTitle>
+          <Text type="secondary" style={{ display: "block", marginTop: 8 }}>
+            Informe os dados que identificam o concurso e o processo
+            administrativo correspondente.
+          </Text>
+
+          <StepActionsConcurso
+            current={current}
+            steps={steps}
+            next={next}
+            prev={prev}
+            onCancel={cancel}
+          />
+        </StyledCardWithoutBorder>
+      </BaseTela>
+    </>
+  );
+};
+
+export default IdentificacaoTela;

--- a/src/pages/Gerenciar/CadastroConcursos/passos/PublicacoesResultadosTela.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/PublicacoesResultadosTela.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Steps, Typography } from "antd";
+import { useNavigate, useParams } from "react-router-dom";
+import BaseTela, { type TitleItem } from "../../../Base/BaseTela";
+import { StepActionsConcurso } from "./StepActionsConcurso";
+import { steps } from "./stepsConcurso";
+import { useConcursoSteps } from "./useConcursoSteps";
+import {
+  CardTitle,
+  ConvocacaoStepsGlobalStyle,
+  StyledCardWithoutBorder,
+} from "@/components/ui";
+
+const { Text } = Typography;
+
+const PublicacoesResultadosTela: React.FC = () => {
+  const navigate = useNavigate();
+  const { uuid } = useParams();
+  const current = 1;
+
+  const { stepItems, handleStepChange } = useConcursoSteps({
+    uuid,
+    currentStepIndex: current,
+    onNavigate: (path) => navigate(path),
+  });
+
+  const breadcrumbItems = [
+    { title: <Text strong>Gerenciar</Text> },
+    {
+      title: (
+        <Text
+          style={{ cursor: "pointer" }}
+          onClick={() => navigate("/gerenciar/concursos")}
+        >
+          Cadastro de concurso
+        </Text>
+      ),
+    },
+    { title: "Adicionar concurso" },
+  ] as TitleItem[];
+
+  const next = () => {
+    navigate(`/gerenciar/concursos/adicionar/${uuid}/passo-3`);
+  };
+
+  const prev = () => {
+    navigate("/gerenciar/concursos/adicionar/passo-1");
+  };
+
+  const cancel = () => {
+    navigate("/gerenciar/concursos");
+  };
+
+  return (
+    <>
+      <ConvocacaoStepsGlobalStyle />
+      <BaseTela breadcrumbItems={breadcrumbItems} title="Adicionar concurso">
+        <StyledCardWithoutBorder variant="borderless">
+          <Steps
+            className="convocacao-steps"
+            current={current}
+            items={stepItems}
+            onChange={handleStepChange}
+          />
+        </StyledCardWithoutBorder>
+
+        <StyledCardWithoutBorder
+          style={{ marginTop: "1.25rem" }}
+          variant="borderless"
+        >
+          <CardTitle>Publicações e resultados</CardTitle>
+          <Text type="secondary" style={{ display: "block", marginTop: 8 }}>
+            Registre as principais publicações e os resultados divulgados ao
+            longo do concurso.
+          </Text>
+
+          <StepActionsConcurso
+            current={current}
+            steps={steps}
+            next={next}
+            prev={prev}
+            onCancel={cancel}
+          />
+        </StyledCardWithoutBorder>
+      </BaseTela>
+    </>
+  );
+};
+
+export default PublicacoesResultadosTela;

--- a/src/pages/Gerenciar/CadastroConcursos/passos/StepActionsConcurso.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/StepActionsConcurso.tsx
@@ -14,10 +14,6 @@ interface StepActionsConcursoProps {
   canVoltar?: boolean;
 }
 
-/**
- * Botões de navegação do cadastro de concurso: "Cancelar", "Anterior",
- * "Próximo" e, no último passo, "Adicionar concurso".
- */
 export const StepActionsConcurso: React.FC<StepActionsConcursoProps> = ({
   current,
   steps,

--- a/src/pages/Gerenciar/CadastroConcursos/passos/StepActionsConcurso.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/StepActionsConcurso.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Row, Col } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { AppButton } from "@/components/ui";
+
+interface StepActionsConcursoProps {
+  current: number;
+  steps: { title: string }[];
+  next: () => void | Promise<void>;
+  prev: () => void;
+  onCancel?: () => void;
+  loading?: boolean;
+  canAvancar?: boolean;
+  canVoltar?: boolean;
+}
+
+/**
+ * Botões de navegação do cadastro de concurso: "Cancelar", "Anterior",
+ * "Próximo" e, no último passo, "Adicionar concurso".
+ */
+export const StepActionsConcurso: React.FC<StepActionsConcursoProps> = ({
+  current,
+  steps,
+  next,
+  prev,
+  onCancel,
+  loading,
+  canAvancar = true,
+  canVoltar = true,
+}) => {
+  const isUltimoPasso = current === steps.length - 1;
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <Row align="middle" justify="end">
+        <Col>
+          {onCancel && (
+            <AppButton
+              variant="secondary"
+              style={{ margin: "0 8px" }}
+              onClick={onCancel}
+            >
+              Cancelar
+            </AppButton>
+          )}
+
+          <AppButton
+            variant="secondary"
+            style={{ margin: "0 8px" }}
+            onClick={prev}
+            disabled={current === 0 || !canVoltar}
+          >
+            Anterior
+          </AppButton>
+
+          {!isUltimoPasso ? (
+            <AppButton
+              variant="primary"
+              style={{ margin: "0 8px" }}
+              onClick={next}
+              loading={loading}
+              disabled={!canAvancar}
+            >
+              Próximo
+            </AppButton>
+          ) : (
+            <AppButton
+              variant="primary"
+              icon={<PlusOutlined />}
+              style={{ margin: "0 8px" }}
+              onClick={next}
+              loading={loading}
+              disabled={!canAvancar}
+            >
+              Adicionar concurso
+            </AppButton>
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/pages/Gerenciar/CadastroConcursos/passos/VigenciaTela.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/VigenciaTela.tsx
@@ -39,7 +39,6 @@ const VigenciaTela: React.FC = () => {
     { title: "Adicionar concurso" },
   ] as TitleItem[];
 
-  // Nesta fase "Finalizar" apenas retorna à listagem, sem request ao backend.
   const next = () => {
     navigate("/gerenciar/concursos");
   };

--- a/src/pages/Gerenciar/CadastroConcursos/passos/VigenciaTela.tsx
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/VigenciaTela.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Steps, Typography } from "antd";
+import { useNavigate, useParams } from "react-router-dom";
+import BaseTela, { type TitleItem } from "../../../Base/BaseTela";
+import { StepActionsConcurso } from "./StepActionsConcurso";
+import { steps } from "./stepsConcurso";
+import { useConcursoSteps } from "./useConcursoSteps";
+import {
+  CardTitle,
+  ConvocacaoStepsGlobalStyle,
+  StyledCardWithoutBorder,
+} from "@/components/ui";
+
+const { Text } = Typography;
+
+const VigenciaTela: React.FC = () => {
+  const navigate = useNavigate();
+  const { uuid } = useParams();
+  const current = 2;
+
+  const { stepItems, handleStepChange } = useConcursoSteps({
+    uuid,
+    currentStepIndex: current,
+    onNavigate: (path) => navigate(path),
+  });
+
+  const breadcrumbItems = [
+    { title: <Text strong>Gerenciar</Text> },
+    {
+      title: (
+        <Text
+          style={{ cursor: "pointer" }}
+          onClick={() => navigate("/gerenciar/concursos")}
+        >
+          Cadastro de concurso
+        </Text>
+      ),
+    },
+    { title: "Adicionar concurso" },
+  ] as TitleItem[];
+
+  // Nesta fase "Finalizar" apenas retorna à listagem, sem request ao backend.
+  const next = () => {
+    navigate("/gerenciar/concursos");
+  };
+
+  const prev = () => {
+    navigate(`/gerenciar/concursos/adicionar/${uuid}/passo-2`);
+  };
+
+  const cancel = () => {
+    navigate("/gerenciar/concursos");
+  };
+
+  return (
+    <>
+      <ConvocacaoStepsGlobalStyle />
+      <BaseTela breadcrumbItems={breadcrumbItems} title="Adicionar concurso">
+        <StyledCardWithoutBorder variant="borderless">
+          <Steps
+            className="convocacao-steps"
+            current={current}
+            items={stepItems}
+            onChange={handleStepChange}
+          />
+        </StyledCardWithoutBorder>
+
+        <StyledCardWithoutBorder
+          style={{ marginTop: "1.25rem" }}
+          variant="borderless"
+        >
+          <CardTitle>Vigência</CardTitle>
+          <Text type="secondary" style={{ display: "block", marginTop: 8 }}>
+            Informe as datas que definem a validade e a vigência do concurso.
+          </Text>
+
+          <StepActionsConcurso
+            current={current}
+            steps={steps}
+            next={next}
+            prev={prev}
+            onCancel={cancel}
+          />
+        </StyledCardWithoutBorder>
+      </BaseTela>
+    </>
+  );
+};
+
+export default VigenciaTela;

--- a/src/pages/Gerenciar/CadastroConcursos/passos/stepsConcurso.ts
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/stepsConcurso.ts
@@ -1,0 +1,16 @@
+export const steps = [
+  {
+    title: "Identificação do concurso",
+    content: "First-content",
+  },
+  {
+    title: "Publicações e resultados",
+    content: "Second-content",
+  },
+  {
+    title: "Vigência",
+    content: "Last-content",
+  },
+];
+
+export const items = steps.map((item) => ({ key: item.title, title: item.title }));

--- a/src/pages/Gerenciar/CadastroConcursos/passos/useConcursoSteps.ts
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/useConcursoSteps.ts
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import { items } from "./stepsConcurso";
+
+type UseConcursoStepsParams = {
+  /** UUID do concurso "criado" no passo 1. Ausente enquanto no passo 1. */
+  uuid?: string;
+  /** Índice 0-based do passo atual. */
+  currentStepIndex: number;
+  onNavigate: (path: string) => void;
+};
+
+/**
+ * Monta os itens do stepper de cadastro de concurso e a lógica de navegação
+ * entre passos. Espelha o comportamento visual de useConvocacaoSteps, porém
+ * sem dependência de progresso vindo do backend: enquanto não existe um uuid
+ * (passo 1), os passos 2 e 3 ficam bloqueados; após o uuid, todos os passos
+ * ficam navegáveis.
+ */
+export function useConcursoSteps(params: UseConcursoStepsParams) {
+  const { uuid, currentStepIndex, onNavigate } = params;
+
+  const getStepPath = (stepIndex: number): string | null => {
+    if (stepIndex === 0) return "/gerenciar/concursos/adicionar/passo-1";
+    if (!uuid) return null;
+    if (stepIndex === 1)
+      return `/gerenciar/concursos/adicionar/${uuid}/passo-2`;
+    return `/gerenciar/concursos/adicionar/${uuid}/passo-3`;
+  };
+
+  const stepItems = useMemo(
+    () =>
+      items.map((item, index) => {
+        const isLocked = !uuid && index > 0;
+        const isVisited = !isLocked && index < currentStepIndex;
+
+        return {
+          ...item,
+          disabled: isLocked,
+          status: index < currentStepIndex ? ("finish" as const) : undefined,
+          className: isLocked
+            ? "step-locked"
+            : isVisited
+              ? "step-visited"
+              : undefined,
+        };
+      }),
+    [uuid, currentStepIndex]
+  );
+
+  const handleStepChange = (nextStep: number) => {
+    if (!uuid && nextStep > 0) return;
+    const nextPath = getStepPath(nextStep);
+    if (nextPath) onNavigate(nextPath);
+  };
+
+  return {
+    stepItems,
+    handleStepChange,
+  };
+}

--- a/src/pages/Gerenciar/CadastroConcursos/passos/useConcursoSteps.ts
+++ b/src/pages/Gerenciar/CadastroConcursos/passos/useConcursoSteps.ts
@@ -9,13 +9,6 @@ type UseConcursoStepsParams = {
   onNavigate: (path: string) => void;
 };
 
-/**
- * Monta os itens do stepper de cadastro de concurso e a lógica de navegação
- * entre passos. Espelha o comportamento visual de useConvocacaoSteps, porém
- * sem dependência de progresso vindo do backend: enquanto não existe um uuid
- * (passo 1), os passos 2 e 3 ficam bloqueados; após o uuid, todos os passos
- * ficam navegáveis.
- */
 export function useConcursoSteps(params: UseConcursoStepsParams) {
   const { uuid, currentStepIndex, onNavigate } = params;
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -24,6 +24,9 @@ import AdicionarUsuarioTela from "../pages/Gerenciar/AdicionarUsuario/AdicionarU
 import CadastroParametrosTela from "../pages/Gerenciar/Parametros/CadastroParametrosTela";
 import ListagemConcursosTela from "../pages/Gerenciar/CadastroConcursos/ListagemConcursosTela";
 import AdicionarEditarConcursoTela from "../pages/Gerenciar/CadastroConcursos/AdicionarEditarConcursoTela";
+import IdentificacaoTela from "../pages/Gerenciar/CadastroConcursos/passos/IdentificacaoTela";
+import PublicacoesResultadosTela from "../pages/Gerenciar/CadastroConcursos/passos/PublicacoesResultadosTela";
+import VigenciaTela from "../pages/Gerenciar/CadastroConcursos/passos/VigenciaTela";
 
 import DadosDoProcesso from "../pages/CriarEditarConvocacao/DadosDoProcesso";
 import SelecaoCargosTela from "../pages/CriarEditarConvocacao/SelecaoCargos/SelecaoCargosTela";
@@ -97,10 +100,37 @@ const router = createBrowserRouter([
   },
   {
     path: "/gerenciar/concursos/adicionar",
+    element: <Navigate to="/gerenciar/concursos/adicionar/passo-1" replace />,
+    errorElement: <RouteError />,
+  },
+  {
+    path: "/gerenciar/concursos/adicionar/passo-1",
     element: (
       <ProtectedRoute>
         <PermissionContextGuard model="concurso" permissaoDeExibirATELA="add_concurso">
-          <AdicionarEditarConcursoTela />
+          <IdentificacaoTela />
+        </PermissionContextGuard>
+      </ProtectedRoute>
+    ),
+    errorElement: <RouteError />,
+  },
+  {
+    path: "/gerenciar/concursos/adicionar/:uuid/passo-2",
+    element: (
+      <ProtectedRoute>
+        <PermissionContextGuard model="concurso" permissaoDeExibirATELA="add_concurso">
+          <PublicacoesResultadosTela />
+        </PermissionContextGuard>
+      </ProtectedRoute>
+    ),
+    errorElement: <RouteError />,
+  },
+  {
+    path: "/gerenciar/concursos/adicionar/:uuid/passo-3",
+    element: (
+      <ProtectedRoute>
+        <PermissionContextGuard model="concurso" permissaoDeExibirATELA="add_concurso">
+          <VigenciaTela />
         </PermissionContextGuard>
       </ProtectedRoute>
     ),


### PR DESCRIPTION
## Descrição
Primeira etapa das alterações no módulo “Adicionar Concurso”: divide o cadastro em três passos navegáveis, seguindo o mesmo padrão visual e de navegação já usado no cadastro de processo de convocação.

Nesta fase, as telas contêm apenas título e subtítulo de cada etapa, com a navegação de avançar/voltar funcionando. Nenhum request POST/PATCH ao backend é feito ainda.

O que foi feito

* Novas telas em src/pages/Gerenciar/CadastroConcursos/passos/:
    * IdentificacaoTela.tsx (passo 1)
    * PublicacoesResultadosTela.tsx (passo 2)
    * VigenciaTela.tsx (passo 3)
* Stepper via Ant Design Steps, reaproveitando ConvocacaoStepsGlobalStyle.
* useConcursoSteps + stepsConcurso: montam os itens do stepper e a lógica de navegação (passos 2 e 3 bloqueados até existir o UUID).
* StepActionsConcurso: botões Cancelar / Anterior / Próximo e, no último passo, “+ Adicionar Concurso”.
* Rotas em src/routes/index.tsx:
    * /gerenciar/concursos/adicionar/passo-1
    * /gerenciar/concursos/adicionar/:uuid/passo-2
    * /gerenciar/concursos/adicionar/:uuid/passo-3
    * /gerenciar/concursos/adicionar redireciona para o passo 1.
* O passo 1 gera o UUID do concurso no cliente e o passa por parâmetro para os passos seguintes. A tela de edição existente permanece inalterada.

- [AB#152901](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/152901)
- [AB#152804](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/152804)